### PR TITLE
✨ Add quit command

### DIFF
--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -3,11 +3,18 @@ defmodule MixTestInteractive do
   Interactively run your Elixir project's tests.
   """
 
-  @spec run([String.t()]) :: :ok
+  @spec run([String.t()]) :: no_return()
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
     :ok = Application.ensure_started(:mix_test_interactive)
-    IO.puts("Interactive mode goes here!")
-    :ok
+    loop()
+  end
+
+  defp loop do
+    cmd = IO.getn("")
+
+    unless cmd == "q" do
+      loop()
+    end
   end
 end


### PR DESCRIPTION
Ideally, the program will accept commands without a trailing newline, but that looks to be very difficult in Elixir/Erlang.  So for now, this requires the user to hit `Enter` to run a command.

One possible solution is to use `ex_ncurses`, but that might cause some portability problems. However, we might need it for later features so we'll consider it at that time.