### PR TITLE
✨ Run tests each time through the loop

### DIFF
--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -3,6 +3,8 @@ defmodule MixTestInteractive do
   Interactively run your Elixir project's tests.
   """
 
+  alias MixTestInteractive.Runner
+
   @spec run([String.t()]) :: no_return()
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
@@ -11,6 +13,7 @@ defmodule MixTestInteractive do
   end
 
   defp loop do
+    Runner.run()
     cmd = IO.getn("")
 
     unless cmd == "q" do

--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -1,0 +1,39 @@
+defmodule MixTestInteractive.PortRunner do
+  @moduledoc """
+  Run the tasks in a new OS process via ports
+  """
+
+  @doc """
+  Run tests.
+  """
+  def run() do
+    command = build_command()
+
+    case :os.type() do
+      {:win32, _} ->
+        System.cmd("cmd", ["/C", "set MIX_ENV=test&& mix test"], into: IO.stream(:stdio, :line))
+
+      _ ->
+        Path.join(:code.priv_dir(:mix_test_interactive), "zombie_killer")
+        |> System.cmd(["sh", "-c", command], into: IO.stream(:stdio, :line))
+    end
+
+    :ok
+  end
+
+  @doc """
+  Build a shell command that runs mix test.
+
+  Colour is forced on- normally Elixir would not print ANSI colours while
+  running inside a port.
+  """
+  def build_command() do
+    ansi = "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+
+    ["mix", "do", ansi <> ",", "test"]
+    |> Enum.filter(& &1)
+    |> Enum.join(" ")
+    |> (fn command -> "MIX_ENV=test #{command}" end).()
+    |> String.trim()
+  end
+end

--- a/lib/mix_test_interactive/runner.ex
+++ b/lib/mix_test_interactive/runner.ex
@@ -1,0 +1,17 @@
+defmodule MixTestInteractive.Runner do
+  @moduledoc false
+
+  alias MixTestInteractive.PortRunner
+
+  @type option :: {:runner, module()}
+
+  @doc """
+  Run tests using provided runner.
+  """
+  @spec run([option]) :: :ok
+  def run(opts \\ []) do
+    runner = Keyword.get(opts, :runner, PortRunner)
+    IO.puts("\nRunning tests...")
+    runner.run()
+  end
+end

--- a/priv/zombie_killer
+++ b/priv/zombie_killer
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Start the program in the background
+exec "$@" &
+pid1=$!
+
+# Silence warnings from here on
+exec >/dev/null 2>&1
+
+# Read from stdin in the background and
+# kill running program when stdin closes
+exec 0<&0 $(
+  while read; do :; done
+  kill -KILL $pid1
+) &
+pid2=$!
+
+# Clean up
+wait $pid1
+ret=$?
+kill -KILL $pid2
+exit $ret

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -1,0 +1,15 @@
+defmodule MixTestInteractive.PortRunnerTest do
+  use ExUnit.Case, async: true
+
+  alias MixTestInteractive.PortRunner
+
+  describe "building a command" do
+    test "builds a command to run mix test ANSI-enabled" do
+      expected =
+        "MIX_ENV=test mix do run -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', test"
+
+      assert PortRunner.build_command() == expected
+    end
+  end
+end

--- a/test/mix_test_interactive/runner_test.exs
+++ b/test/mix_test_interactive/runner_test.exs
@@ -1,0 +1,36 @@
+defmodule MixTestInteractive.RunnerTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias MixTestInteractive.Runner
+
+  defmodule DummyRunner do
+    def run() do
+      Agent.get_and_update(__MODULE__, fn runs -> {:ok, runs + 1} end)
+    end
+  end
+
+  setup do
+    {:ok, _} = Agent.start_link(fn -> 0 end, name: DummyRunner)
+    :ok
+  end
+
+  describe "running tests" do
+    test "delegates to the provided runner" do
+      options = [runner: DummyRunner]
+
+      output =
+        capture_io(fn ->
+          Runner.run(options)
+        end)
+
+      assert Agent.get(DummyRunner, fn x -> x end) == 1
+
+      assert output == """
+
+             Running tests...
+             """
+    end
+  end
+end


### PR DESCRIPTION
Runs `mix test` in ANSI color mode at startup and after each command (other than `q`).

A side effect of this is that hitting `Enter` (empty command) will also re-run the tests, which is the desired feature.