### PR TITLE
✨ Support all mix-test.watch configuration options

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,13 @@ jobs:
       - checkout
       - restore_cache:
           keys:
+            - v1-mix-deps-<< parameters.elixir >>-{{checksum "mix.lock"}}
             - v1-mix-deps-<< parameters.elixir >>
       - run: mix local.hex --force
       - run: mix local.rebar --force
       - run: mix do deps.get --only test, deps.compile, compile
       - save_cache:
-          key: v1-mix-deps-<< parameters.elixir >>
+          key: v1-mix-deps-<< parameters.elixir >>-{{checksum "mix.lock"}}
           paths:
             - _build
             - deps

--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -3,21 +3,22 @@ defmodule MixTestInteractive do
   Interactively run your Elixir project's tests.
   """
 
-  alias MixTestInteractive.Runner
+  alias MixTestInteractive.{Config, Runner}
 
   @spec run([String.t()]) :: no_return()
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
+    config = Config.new(args)
     :ok = Application.ensure_started(:mix_test_interactive)
-    loop()
+    loop(config)
   end
 
-  defp loop do
-    Runner.run()
+  defp loop(config) do
+    Runner.run(config)
     cmd = IO.getn("")
 
     unless cmd == "q" do
-      loop()
+      loop(config)
     end
   end
 end

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -1,0 +1,68 @@
+defmodule MixTestInteractive.Config do
+  @moduledoc """
+  Responsible for gathering and packaging the configuration for the task.
+  """
+  @application :mix_test_interactive
+
+  @default_runner MixTestInteractive.PortRunner
+  @default_tasks ~w(test)
+  @default_clear false
+  @default_timestamp false
+  @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
+  @default_extra_extensions []
+  @default_cli_executable "mix"
+
+  defstruct tasks: @default_tasks,
+            clear: @default_clear,
+            timestamp: @default_timestamp,
+            runner: @default_runner,
+            exclude: @default_exclude,
+            extra_extensions: @default_extra_extensions,
+            cli_executable: @default_cli_executable,
+            cli_args: []
+
+  @spec new([String.t()]) :: %__MODULE__{}
+  @doc """
+  Create a new config struct, taking values from the ENV
+  """
+  def new(cli_args \\ []) do
+    %__MODULE__{
+      tasks: get_tasks(),
+      clear: get_clear(),
+      timestamp: get_timestamp(),
+      runner: get_runner(),
+      exclude: get_excluded(),
+      cli_executable: get_cli_executable(),
+      cli_args: cli_args,
+      extra_extensions: get_extra_extensions()
+    }
+  end
+
+  defp get_runner do
+    Application.get_env(@application, :runner, @default_runner)
+  end
+
+  defp get_tasks do
+    Application.get_env(@application, :tasks, @default_tasks)
+  end
+
+  defp get_clear do
+    Application.get_env(@application, :clear, @default_clear)
+  end
+
+  defp get_timestamp do
+    Application.get_env(@application, :timestamp, @default_timestamp)
+  end
+
+  defp get_excluded do
+    Application.get_env(@application, :exclude, @default_exclude)
+  end
+
+  defp get_cli_executable do
+    Application.get_env(@application, :cli_executable, @default_cli_executable)
+  end
+
+  defp get_extra_extensions do
+    Application.get_env(@application, :extra_extensions, @default_extra_extensions)
+  end
+end

--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -3,18 +3,22 @@ defmodule MixTestInteractive.PortRunner do
   Run the tasks in a new OS process via ports
   """
 
+  @application :mix_test_interactive
+
+  alias MixTestInteractive.Config
+
   @doc """
-  Run tests.
+  Run tests using the runner from the config.
   """
-  def run() do
-    command = build_command()
+  def run(%Config{} = config) do
+    command = build_tasks_cmds(config)
 
     case :os.type() do
       {:win32, _} ->
         System.cmd("cmd", ["/C", "set MIX_ENV=test&& mix test"], into: IO.stream(:stdio, :line))
 
       _ ->
-        Path.join(:code.priv_dir(:mix_test_interactive), "zombie_killer")
+        Path.join(:code.priv_dir(@application), "zombie_killer")
         |> System.cmd(["sh", "-c", command], into: IO.stream(:stdio, :line))
     end
 
@@ -22,15 +26,27 @@ defmodule MixTestInteractive.PortRunner do
   end
 
   @doc """
-  Build a shell command that runs mix test.
+  Build a shell command that runs the desired mix task(s).
 
   Colour is forced on- normally Elixir would not print ANSI colours while
   running inside a port.
   """
-  def build_command() do
-    ansi = "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+  def build_tasks_cmds(%Config{} = config) do
+    config.tasks
+    |> Enum.map(&task_command(&1, config))
+    |> Enum.join(" && ")
+  end
 
-    ["mix", "do", ansi <> ",", "test"]
+  defp task_command(task, config) do
+    args = Enum.join(config.cli_args, " ")
+
+    ansi =
+      case Enum.member?(config.cli_args, "--no-start") do
+        true -> "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+        false -> "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
+      end
+
+    [config.cli_executable, "do", ansi <> ",", task, args]
     |> Enum.filter(& &1)
     |> Enum.join(" ")
     |> (fn command -> "MIX_ENV=test #{command}" end).()

--- a/lib/mix_test_interactive/runner.ex
+++ b/lib/mix_test_interactive/runner.ex
@@ -1,17 +1,28 @@
 defmodule MixTestInteractive.Runner do
   @moduledoc false
 
-  alias MixTestInteractive.PortRunner
-
-  @type option :: {:runner, module()}
+  alias MixTestInteractive.Config
 
   @doc """
   Run tests using provided runner.
   """
-  @spec run([option]) :: :ok
-  def run(opts \\ []) do
-    runner = Keyword.get(opts, :runner, PortRunner)
+  @spec run(Config.t()) :: :ok
+  def run(config) do
+    :ok = maybe_clear_terminal(config)
     IO.puts("\nRunning tests...")
-    runner.run()
+    :ok = maybe_print_timestamp(config)
+    config.runner.run(config)
+  end
+
+  defp maybe_clear_terminal(%{clear: false}), do: :ok
+  defp maybe_clear_terminal(%{clear: true}), do: :ok = IO.puts(IO.ANSI.clear() <> IO.ANSI.home())
+
+  defp maybe_print_timestamp(%{timestamp: false}), do: :ok
+
+  defp maybe_print_timestamp(%{timestamp: true}) do
+    :ok =
+      DateTime.utc_now()
+      |> DateTime.to_string()
+      |> IO.puts()
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,6 @@ defmodule MixTestInteractive.MixProject do
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger],
@@ -21,11 +20,9 @@ defmodule MixTestInteractive.MixProject do
     ]
   end
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:temporary_env, "~> 2.0", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,3 @@
+%{
+  "temporary_env": {:hex, :temporary_env, "2.0.1", "d4b5e031837e5619485e1f23af7cba7e897b8fd546eaaa8b10c812d642ec4546", [:mix], [], "hexpm", "f9420044742b5f0479a7f8243e86b048b6a2d4878bce026a3615065b11199c27"},
+}

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -1,0 +1,76 @@
+defmodule MixTestInteractive.ConfigTest do
+  use ExUnit.Case, async: false
+  use TemporaryEnv
+
+  alias MixTestInteractive.Config
+
+  test "new/1 takes :tasks from the env" do
+    TemporaryEnv.put :mix_test_interactive, :tasks, :env_tasks do
+      config = Config.new()
+      assert config.tasks == :env_tasks
+    end
+  end
+
+  test ~s(new/1 defaults :tasks to ["test"]) do
+    TemporaryEnv.delete :mix_test_interactive, :tasks do
+      config = Config.new()
+      assert config.tasks == ["test"]
+    end
+  end
+
+  test "new/1 takes :exclude from the env" do
+    TemporaryEnv.put :mix_test_interactive, :exclude, [~r/migration_.*/] do
+      config = Config.new()
+      assert config.exclude == [~r/migration_.*/]
+    end
+  end
+
+  test ":exclude contains common editor temp/swap files by default" do
+    config = Config.new()
+    # Emacs lock symlink
+    assert ~r/\.#/ in config.exclude
+  end
+
+  test ":exclude contains default Phoenix migrations directory by default" do
+    config = Config.new()
+    assert ~r{priv/repo/migrations} in config.exclude
+  end
+
+  test "new/1 takes :extra_extensions from the env" do
+    TemporaryEnv.put :mix_test_interactive, :extra_extensions, [".haml"] do
+      config = Config.new()
+      assert config.extra_extensions == [".haml"]
+    end
+  end
+
+  test "new/1 passes cli_args" do
+    config = Config.new(["hello", "world"])
+    assert config.cli_args == ["hello", "world"]
+  end
+
+  test "new/1 default cli_args to empty list" do
+    config = Config.new()
+    assert config.cli_args == []
+  end
+
+  test "new/1 takes :clear from the env" do
+    TemporaryEnv.put :mix_test_interactive, :clear, true do
+      config = Config.new()
+      assert config.clear
+    end
+  end
+
+  test "new/1 takes :timestamp from the env" do
+    TemporaryEnv.put :mix_test_interactive, :timestamp, true do
+      config = Config.new()
+      assert config.timestamp
+    end
+  end
+
+  test "new/1 takes :shell_prefix from the env" do
+    TemporaryEnv.put :mix_test_interactive, :cli_executable, "iex -S" do
+      config = Config.new()
+      assert config.cli_executable == "iex -S"
+    end
+  end
+end

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -1,15 +1,38 @@
 defmodule MixTestInteractive.PortRunnerTest do
   use ExUnit.Case, async: true
 
-  alias MixTestInteractive.PortRunner
+  alias MixTestInteractive.{Config, PortRunner}
 
-  describe "building a command" do
-    test "builds a command to run mix test ANSI-enabled" do
+  describe "build_tasks_cmds/1" do
+    test "appends commandline arguments from passed config" do
+      config = %Config{cli_args: ["--exclude", "integration"]}
+
       expected =
         "MIX_ENV=test mix do run -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
+
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
+
+    test "take the command cli_executable from passed config" do
+      config = %Config{cli_executable: "iex -S mix"}
+
+      expected =
+        "MIX_ENV=test iex -S mix do run -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', test"
 
-      assert PortRunner.build_command() == expected
+      assert PortRunner.build_tasks_cmds(config) == expected
+    end
+
+    test "respect no-start commandline argument from passed config" do
+      config = %Config{cli_args: ["--exclude", "integration", "--no-start"]}
+
+      expected =
+        "MIX_ENV=test mix do run --no-start -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
+          "test --exclude integration --no-start"
+
+      assert PortRunner.build_tasks_cmds(config) == expected
     end
   end
 end

--- a/test/mix_test_interactive/runner_test.exs
+++ b/test/mix_test_interactive/runner_test.exs
@@ -3,34 +3,58 @@ defmodule MixTestInteractive.RunnerTest do
 
   import ExUnit.CaptureIO
 
-  alias MixTestInteractive.Runner
+  alias MixTestInteractive.{Config, Runner}
 
   defmodule DummyRunner do
-    def run() do
-      Agent.get_and_update(__MODULE__, fn runs -> {:ok, runs + 1} end)
+    def run(config) do
+      Agent.get_and_update(__MODULE__, fn data -> {:ok, [config | data]} end)
     end
   end
 
   setup do
-    {:ok, _} = Agent.start_link(fn -> 0 end, name: DummyRunner)
+    {:ok, _} = Agent.start_link(fn -> [] end, name: DummyRunner)
     :ok
   end
 
-  describe "running tests" do
-    test "delegates to the provided runner" do
-      options = [runner: DummyRunner]
+  describe "run/1" do
+    test "It delegates to the runner specified by the config" do
+      config = %Config{runner: DummyRunner}
 
       output =
         capture_io(fn ->
-          Runner.run(options)
+          Runner.run(config)
         end)
 
-      assert Agent.get(DummyRunner, fn x -> x end) == 1
+      assert Agent.get(DummyRunner, fn x -> x end) == [config]
 
       assert output == """
 
              Running tests...
              """
+    end
+
+    test "It outputs timestamp when specified by the config" do
+      config = %Config{runner: DummyRunner, timestamp: true}
+
+      output =
+        capture_io(fn ->
+          Runner.run(config)
+        end)
+
+      assert Agent.get(DummyRunner, fn x -> x end) == [config]
+
+      timestamp =
+        output
+        |> String.replace_leading(
+          """
+
+          Running tests...
+          """,
+          ""
+        )
+        |> String.trim()
+
+      assert {:ok, _} = NaiveDateTime.from_iso8601(timestamp)
     end
   end
 end


### PR DESCRIPTION
Support the same set of configuration options as `mix-test.watch`, including the ability to pass command-line arguments on to `mix test`.

Also, add mix.lock checksum to CI cache key. Now that we have a mix dependency, we can have a more focused CI cache based on `mix.lock`'s checksum.