### PR TITLE
🐛 Fix issues with listener loop

### DIFF
--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -3,22 +3,30 @@ defmodule MixTestInteractive do
   Interactively run your Elixir project's tests.
   """
 
-  alias MixTestInteractive.{Config, Runner}
+  alias MixTestInteractive.{CommandProcessor, Config, Runner}
 
-  @spec run([String.t()]) :: no_return()
+  @spec run([String.t()]) :: :ok
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
     config = Config.new(args)
     :ok = Application.ensure_started(:mix_test_interactive)
+    Runner.run(config)
     loop(config)
   end
 
   defp loop(config) do
-    Runner.run(config)
-    cmd = IO.getn("")
+    command = IO.gets("")
 
-    unless cmd == "q" do
-      loop(config)
+    case CommandProcessor.process_command(command, config) do
+      {:ok, new_config} ->
+        Runner.run(new_config)
+        loop(new_config)
+
+      :unknown ->
+        loop(config)
+
+      :quit ->
+        :ok
     end
   end
 end

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -1,0 +1,19 @@
+defmodule MixTestInteractive.CommandProcessor do
+  @moduledoc false
+
+  alias MixTestInteractive.Config
+
+  @spec process_command(String.t() | :eof, Config.t()) :: {:ok, Config.t()} | :unknown | :quit
+
+  def process_command(:eof, _config), do: :quit
+
+  def process_command(command, config) when is_binary(command) do
+    command
+    |> String.trim()
+    |> do_process_command(config)
+  end
+
+  defp do_process_command("q", _config), do: :quit
+  defp do_process_command("", config), do: {:ok, config}
+  defp do_process_command(_unknown_command, _config), do: :unknown
+end

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -1,0 +1,22 @@
+defmodule MixTestInteractive.CommandProcessorTest do
+  use ExUnit.Case, async: true
+
+  alias MixTestInteractive.{CommandProcessor, Config}
+
+  defp process_command(command) do
+    config = Config.new([])
+    CommandProcessor.process_command(command, config)
+  end
+
+  test "returns :quit on :eof" do
+    assert :quit = process_command(:eof)
+  end
+
+  test "returns :quit for q command" do
+    assert :quit = process_command("q")
+  end
+
+  test "trims whitespace from commands" do
+    assert :quit = process_command("\t  q   \n   \t")
+  end
+end


### PR DESCRIPTION
- Using `IO.getn` was resulting in double test runs.

- We were re-running tests on unrecognized commands.

- `Ctrl-D` (EOF) wasn't being handled properly

Switched to using `IO.gets` to read commands.

Extracted a CommandProcessor for handling the commands; it handles `:eof` the same way as the `q` command, trims whitespace from string commands, and ignores unknown commands.

The CommandProcessor takes and returns a config; it currently doesn't make any changes to it, but future commands will.

The main loop now only runs the tests when a non-quit command is recognized.