### PR TITLE
♻️ Extract main loop to new module

### DIFF
--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -3,40 +3,14 @@ defmodule MixTestInteractive do
   Interactively run your Elixir project's tests.
   """
 
-  alias MixTestInteractive.{CommandProcessor, Config, Runner}
+  alias MixTestInteractive.{Config, InteractiveMode}
 
   @spec run([String.t()]) :: :ok
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
     config = Config.new(args)
     :ok = Application.ensure_started(:mix_test_interactive)
-    run_tests(config)
-    loop(config)
-  end
 
-  defp loop(config) do
-    command = IO.gets("")
-
-    case CommandProcessor.process_command(command, config) do
-      {:ok, new_config} ->
-        run_tests(new_config)
-        loop(new_config)
-
-      :unknown ->
-        loop(config)
-
-      :quit ->
-        :ok
-    end
-  end
-
-  defp run_tests(config) do
-    Runner.run(config)
-    show_usage()
-  end
-
-  defp show_usage() do
-    IO.puts("")
-    IO.puts(CommandProcessor.usage())
+    InteractiveMode.start(config)
   end
 end

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -3,14 +3,14 @@ defmodule MixTestInteractive.CommandProcessor do
 
   alias MixTestInteractive.Config
 
-  @spec process_command(String.t() | :eof, Config.t()) :: {:ok, Config.t()} | :unknown | :quit
+  @spec call(String.t() | :eof, Config.t()) :: {:ok, Config.t()} | :unknown | :quit
 
-  def process_command(:eof, _config), do: :quit
+  def call(:eof, _config), do: :quit
 
-  def process_command(command, config) when is_binary(command) do
+  def call(command, config) when is_binary(command) do
     command
     |> String.trim()
-    |> do_process_command(config)
+    |> process_command(config)
   end
 
   def usage do
@@ -21,7 +21,7 @@ defmodule MixTestInteractive.CommandProcessor do
     """
   end
 
-  defp do_process_command("q", _config), do: :quit
-  defp do_process_command("", config), do: {:ok, config}
-  defp do_process_command(_unknown_command, _config), do: :unknown
+  defp process_command("q", _config), do: :quit
+  defp process_command("", config), do: {:ok, config}
+  defp process_command(_unknown_command, _config), do: :unknown
 end

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -1,0 +1,34 @@
+defmodule MixTestInteractive.InteractiveMode do
+  alias MixTestInteractive.{CommandProcessor, Runner}
+
+  def start(config) do
+    run_tests(config)
+    loop(config)
+  end
+
+  defp loop(config) do
+    command = IO.gets("")
+
+    case CommandProcessor.call(command, config) do
+      {:ok, new_config} ->
+        run_tests(new_config)
+        loop(new_config)
+
+      :unknown ->
+        loop(config)
+
+      :quit ->
+        :ok
+    end
+  end
+
+  defp run_tests(config) do
+    Runner.run(config)
+    show_usage()
+  end
+
+  defp show_usage() do
+    IO.puts("")
+    IO.puts(CommandProcessor.usage())
+  end
+end

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -4,7 +4,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
   alias MixTestInteractive.{CommandProcessor, Config}
 
   defp process_command(command, config \\ Config.new([])) do
-    CommandProcessor.process_command(command, config)
+    CommandProcessor.call(command, config)
   end
 
   describe "commands" do


### PR DESCRIPTION
New InteractiveMode module now house the main loop.

Also, rename `CommandProcessor.process_command` to `call`.