### PR TITLE
✨ Run tests after files change

### DIFF
--- a/lib/mix_test_interactive.ex
+++ b/lib/mix_test_interactive.ex
@@ -8,8 +8,9 @@ defmodule MixTestInteractive do
   @spec run([String.t()]) :: :ok
   def run(args \\ []) when is_list(args) do
     Mix.env(:test)
+    {:ok, _} = Application.ensure_all_started(:mix_test_interactive)
+
     config = Config.new(args)
-    :ok = Application.ensure_started(:mix_test_interactive)
 
     InteractiveMode.start(config)
   end

--- a/lib/mix_test_interactive/application.ex
+++ b/lib/mix_test_interactive/application.ex
@@ -3,9 +3,11 @@ defmodule MixTestInteractive.Application do
 
   use Application
 
+  alias MixTestInteractive.{Config, ConfigStore}
+
   @impl Application
   def start(_type, _args) do
-    children = []
+    children = [{ConfigStore, config: %Config{}}]
 
     opts = [strategy: :one_for_one, name: MixTestInteractive.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/mix_test_interactive/application.ex
+++ b/lib/mix_test_interactive/application.ex
@@ -3,11 +3,11 @@ defmodule MixTestInteractive.Application do
 
   use Application
 
-  alias MixTestInteractive.{Config, ConfigStore}
+  alias MixTestInteractive.{Config, ConfigStore, Watcher}
 
   @impl Application
   def start(_type, _args) do
-    children = [{ConfigStore, config: %Config{}}]
+    children = [{ConfigStore, config: %Config{}}, Watcher]
 
     opts = [strategy: :one_for_one, name: MixTestInteractive.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/mix_test_interactive/config_store.ex
+++ b/lib/mix_test_interactive/config_store.ex
@@ -1,0 +1,15 @@
+defmodule MixTestInteractive.ConfigStore do
+  use Agent
+
+  def start_link(_initial) do
+    Agent.start_link(fn -> nil end, name: __MODULE__)
+  end
+
+  def store(config) do
+    Agent.update(__MODULE__, fn _ -> config end)
+  end
+
+  def config do
+    Agent.get(__MODULE__, & &1)
+  end
+end

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -1,7 +1,8 @@
 defmodule MixTestInteractive.InteractiveMode do
-  alias MixTestInteractive.{CommandProcessor, Runner}
+  alias MixTestInteractive.{CommandProcessor, ConfigStore, Runner}
 
   def start(config) do
+    ConfigStore.store(config)
     run_tests(config)
     loop(config)
   end
@@ -11,6 +12,7 @@ defmodule MixTestInteractive.InteractiveMode do
 
     case CommandProcessor.call(command, config) do
       {:ok, new_config} ->
+        ConfigStore.store(new_config)
         run_tests(new_config)
         loop(new_config)
 

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -7,6 +7,11 @@ defmodule MixTestInteractive.InteractiveMode do
     loop(config)
   end
 
+  def run_tests(config) do
+    Runner.run(config)
+    show_usage()
+  end
+
   defp loop(config) do
     command = IO.gets("")
 
@@ -22,11 +27,6 @@ defmodule MixTestInteractive.InteractiveMode do
       :quit ->
         :ok
     end
-  end
-
-  defp run_tests(config) do
-    Runner.run(config)
-    show_usage()
   end
 
   defp show_usage() do

--- a/lib/mix_test_interactive/message_inbox.ex
+++ b/lib/mix_test_interactive/message_inbox.ex
@@ -1,0 +1,17 @@
+defmodule MixTestInteractive.MessageInbox do
+  @moduledoc """
+  Helpers for managing process messages.
+  """
+
+  @spec flush :: :ok
+  @doc """
+  Clear the process inbox of all messages.
+  """
+  def flush do
+    receive do
+      _ -> flush()
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/lib/mix_test_interactive/paths.ex
+++ b/lib/mix_test_interactive/paths.ex
@@ -1,0 +1,41 @@
+defmodule MixTestInteractive.Paths do
+  @moduledoc """
+  Decides if we should refresh for a path.
+  """
+
+  alias MixTestInteractive.Config
+
+  @elixir_source_endings ~w(.erl .ex .exs .eex .leex .xrl .yrl .hrl)
+  @ignored_dirs ~w(deps/ _build/)
+
+  #
+  # Public API
+  #
+
+  @spec watching?(String.t(), Config.t()) :: boolean
+
+  def watching?(path, config \\ %Config{}) do
+    watched_directory?(path) and elixir_extension?(path, config.extra_extensions) and
+      not excluded?(config, path)
+  end
+
+  #
+  # Internal functions
+  #
+
+  @spec excluded?(Config.t(), String.t()) :: boolean
+
+  defp excluded?(config, path) do
+    config.exclude
+    |> Enum.map(fn pattern -> Regex.match?(pattern, path) end)
+    |> Enum.any?()
+  end
+
+  defp watched_directory?(path) do
+    not String.starts_with?(path, @ignored_dirs)
+  end
+
+  defp elixir_extension?(path, extra_extensions) do
+    String.ends_with?(path, @elixir_source_endings ++ extra_extensions)
+  end
+end

--- a/lib/mix_test_interactive/watcher.ex
+++ b/lib/mix_test_interactive/watcher.ex
@@ -1,0 +1,46 @@
+defmodule MixTestInteractive.Watcher do
+  use GenServer
+
+  alias MixTestInteractive.{ConfigStore, InteractiveMode, MessageInbox, Paths}
+
+  require Logger
+
+  @moduledoc """
+  A server that runs tests whenever source files change.
+  """
+
+  def start_link(_args) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_) do
+    opts = [dirs: [Path.absname("")], name: :mix_test_watcher]
+
+    case FileSystem.start_link(opts) do
+      {:ok, _} ->
+        FileSystem.subscribe(:mix_test_watcher)
+        {:ok, []}
+
+      other ->
+        Logger.warn("""
+        Could not start the file system monitor.
+        """)
+
+        other
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:file_event, _, {path, _events}}, state) do
+    config = ConfigStore.config()
+    path = to_string(path)
+
+    if Paths.watching?(path, config) do
+      InteractiveMode.run_tests(config)
+      MessageInbox.flush()
+    end
+
+    {:noreply, state}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,13 +15,14 @@ defmodule MixTestInteractive.MixProject do
 
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :file_system],
       mod: {MixTestInteractive.Application, []}
     ]
   end
 
   defp deps do
     [
+      {:file_system, "~> 0.2"},
       {:temporary_env, "~> 2.0", only: :test}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
 %{
+  "file_system": {:hex, :file_system, "0.2.10", "fb082005a9cd1711c05b5248710f8826b02d7d1784e7c3451f9c1231d4fc162d", [:mix], [], "hexpm", "41195edbfb562a593726eda3b3e8b103a309b733ad25f3d642ba49696bf715dc"},
   "temporary_env": {:hex, :temporary_env, "2.0.1", "d4b5e031837e5619485e1f23af7cba7e897b8fd546eaaa8b10c812d642ec4546", [:mix], [], "hexpm", "f9420044742b5f0479a7f8243e86b048b6a2d4878bce026a3615065b11199c27"},
 }

--- a/test/mix_test_interactive/message_inbox_test.exs
+++ b/test/mix_test_interactive/message_inbox_test.exs
@@ -1,0 +1,10 @@
+defmodule MixTestInteractive.MessageInboxTest do
+  use ExUnit.Case
+  alias MixTestInteractive.MessageInbox
+
+  test "flush clears the process inbox of messages" do
+    Enum.each(1..10, &send(self(), &1))
+    MessageInbox.flush()
+    refute_received _any_messages
+  end
+end

--- a/test/mix_test_interactive/paths_test.exs
+++ b/test/mix_test_interactive/paths_test.exs
@@ -1,0 +1,76 @@
+defmodule MixTestInteractive.PathTest do
+  use ExUnit.Case
+
+  import MixTestInteractive.Paths, only: [watching?: 1, watching?: 2]
+  alias MixTestInteractive.Config
+
+  test ".ex files are watched" do
+    assert watching?("foo.ex")
+  end
+
+  test ".exs files are watched" do
+    assert watching?("foo.exs")
+  end
+
+  test ".eex files are watched" do
+    assert watching?("foo.eex")
+  end
+
+  test ".leex files are watched" do
+    assert watching?("foo.leex")
+  end
+
+  test ".erl files are watched" do
+    assert watching?("foo.erl")
+  end
+
+  test ".xrl files are watched" do
+    assert watching?("foo.xrl")
+  end
+
+  test ".yrl files are watched" do
+    assert watching?("foo.yrl")
+  end
+
+  test ".hrl files are watched" do
+    assert watching?("foo.hrl")
+  end
+
+  test "extra extensions are watched" do
+    config = %Config{extra_extensions: [".ex", ".haml", ".foo", ".txt"]}
+    assert watching?("foo.ex", config)
+    assert watching?("index.html.haml", config)
+    assert watching?("my.foo", config)
+    assert watching?("best.txt", config)
+  end
+
+  test "misc files are not watched" do
+    refute watching?("foo.rb")
+    refute watching?("foo.js")
+    refute watching?("foo.css")
+    refute watching?("foo.lock")
+    refute watching?("foo.html")
+    refute watching?("foo.yaml")
+    refute watching?("foo.json")
+  end
+
+  test "_build directory is not watched" do
+    refute watching?("_build/dev/lib/mix_test_watch/ebin/mix_test_watch.ex")
+    refute watching?("_build/dev/lib/mix_test_watch/ebin/mix_test_watch.exs")
+    refute watching?("_build/dev/lib/mix_test_watch/ebin/mix_test_watch.eex")
+  end
+
+  test "deps directory is not watched" do
+    refute watching?("deps/dogma/lib/dogma.ex")
+    refute watching?("deps/dogma/lib/dogma.exs")
+    refute watching?("deps/dogma/lib/dogma.eex")
+  end
+
+  test "migrations_.* files should be excluded watched" do
+    refute watching?("migrations_files/foo.exs", %Config{exclude: [~r/migrations_.*/]})
+  end
+
+  test "app.ex is not excluded by migrations_.* pattern" do
+    assert watching?("app.ex", %Config{exclude: [~r/migrations_.*/]})
+  end
+end


### PR DESCRIPTION
Brings in `Watcher` and friends from mix-test.watch.

Introduces a `ConfigStore` agent for storing the config and sharing it between the watcher and the interactive mode.