### PR TITLE
✨ Allow restricting the files to run

### DIFF
--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -7,21 +7,32 @@ defmodule MixTestInteractive.CommandProcessor do
 
   def call(:eof, _config), do: :quit
 
-  def call(command, config) when is_binary(command) do
-    command
-    |> String.trim()
-    |> process_command(config)
+  def call(command_line, config) when is_binary(command_line) do
+    case String.split(command_line) do
+      [] -> process_command("", [], config)
+      [command | args] -> process_command(command, args, config)
+    end
   end
 
   def usage do
     """
     Usage
-    › Press Enter to trigger a test run.
-    › Press q to quit.
+    › p <files> to run only the specified test files.
+    › c to clear any file filters.
+    › Enter to trigger a test run.
+    › q to quit.
     """
   end
 
-  defp process_command("q", _config), do: :quit
-  defp process_command("", config), do: {:ok, config}
-  defp process_command(_unknown_command, _config), do: :unknown
+  defp process_command("p", files, config) do
+    {:ok, Config.only_files(config, files)}
+  end
+
+  defp process_command("c", _args, config) do
+    {:ok, Config.all_files(config)}
+  end
+
+  defp process_command("q", _args, _config), do: :quit
+  defp process_command("", _args, config), do: {:ok, config}
+  defp process_command(_unknown_command, _args, _config), do: :unknown
 end

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -16,6 +16,7 @@ defmodule MixTestInteractive.Config do
             cli_executable: @default_cli_executable,
             exclude: @default_exclude,
             extra_extensions: @default_extra_extensions,
+            files: [],
             initial_cli_args: [],
             runner: @default_runner,
             tasks: @default_tasks,
@@ -31,6 +32,7 @@ defmodule MixTestInteractive.Config do
       cli_executable: get_cli_executable(),
       exclude: get_excluded(),
       extra_extensions: get_extra_extensions(),
+      files: [],
       initial_cli_args: cli_args,
       runner: get_runner(),
       tasks: get_tasks(),
@@ -38,7 +40,15 @@ defmodule MixTestInteractive.Config do
     }
   end
 
-  def cli_args(%__MODULE__{initial_cli_args: cli_args}), do: cli_args
+  def cli_args(%__MODULE__{files: files, initial_cli_args: cli_args}), do: cli_args ++ files
+
+  def all_files(config) do
+    %{config | files: []}
+  end
+
+  def only_files(config, files) do
+    %{config | files: files}
+  end
 
   defp get_runner do
     Application.get_env(@application, :runner, @default_runner)

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -12,14 +12,14 @@ defmodule MixTestInteractive.Config do
   @default_extra_extensions []
   @default_cli_executable "mix"
 
-  defstruct tasks: @default_tasks,
-            clear: @default_clear,
-            timestamp: @default_timestamp,
-            runner: @default_runner,
+  defstruct clear: @default_clear,
+            cli_executable: @default_cli_executable,
             exclude: @default_exclude,
             extra_extensions: @default_extra_extensions,
-            cli_executable: @default_cli_executable,
-            cli_args: []
+            initial_cli_args: [],
+            runner: @default_runner,
+            tasks: @default_tasks,
+            timestamp: @default_timestamp
 
   @spec new([String.t()]) :: %__MODULE__{}
   @doc """
@@ -27,16 +27,18 @@ defmodule MixTestInteractive.Config do
   """
   def new(cli_args \\ []) do
     %__MODULE__{
-      tasks: get_tasks(),
       clear: get_clear(),
-      timestamp: get_timestamp(),
-      runner: get_runner(),
-      exclude: get_excluded(),
       cli_executable: get_cli_executable(),
-      cli_args: cli_args,
-      extra_extensions: get_extra_extensions()
+      exclude: get_excluded(),
+      extra_extensions: get_extra_extensions(),
+      initial_cli_args: cli_args,
+      runner: get_runner(),
+      tasks: get_tasks(),
+      timestamp: get_timestamp()
     }
   end
+
+  def cli_args(%__MODULE__{initial_cli_args: cli_args}), do: cli_args
 
   defp get_runner do
     Application.get_env(@application, :runner, @default_runner)

--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -38,10 +38,11 @@ defmodule MixTestInteractive.PortRunner do
   end
 
   defp task_command(task, config) do
-    args = Enum.join(config.cli_args, " ")
+    cli_args = Config.cli_args(config)
+    args = Enum.join(cli_args, " ")
 
     ansi =
-      case Enum.member?(config.cli_args, "--no-start") do
+      case Enum.member?(cli_args, "--no-start") do
         true -> "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
         false -> "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
       end

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -8,17 +8,32 @@ defmodule MixTestInteractive.CommandProcessorTest do
   end
 
   describe "commands" do
-    test "returns :quit on :eof" do
+    test ":eof returns :quit" do
       assert :quit = process_command(:eof)
     end
 
-    test "returns :quit on q command" do
+    test "q returns :quit" do
       assert :quit = process_command("q")
     end
 
-    test "returns ok tuple on Enter" do
-      config = Config.new([])
+    test "Enter returns ok tuple" do
+      config = Config.new()
       assert {:ok, ^config} = process_command("", config)
+    end
+
+    test "p restricts files to provided list" do
+      config = Config.new()
+      files = ["file1", "file2"]
+      expected = Config.only_files(config, files)
+
+      assert {:ok, ^expected} = process_command("p file1 file2")
+    end
+
+    test "c clears file restrictions" do
+      config = Config.new() |> Config.only_files("file")
+      expected = Config.all_files(config)
+
+      assert {:ok, ^expected} = process_command("c")
     end
 
     test "trims whitespace from commands" do
@@ -28,13 +43,12 @@ defmodule MixTestInteractive.CommandProcessorTest do
 
   describe "usage information" do
     test "usage describes all commands" do
-      expected = """
-      Usage
-      › Press Enter to trigger a test run.
-      › Press q to quit.
-      """
-
-      assert CommandProcessor.usage() == expected
+      usage = CommandProcessor.usage()
+      assert usage =~ ~r/^Usage/
+      assert usage =~ ~r/^› p/m
+      assert usage =~ ~r/^› c/m
+      assert usage =~ ~r/^› Enter/m
+      assert usage =~ ~r/^› q/m
     end
   end
 end

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -45,12 +45,12 @@ defmodule MixTestInteractive.ConfigTest do
 
   test "new/1 passes cli_args" do
     config = Config.new(["hello", "world"])
-    assert config.cli_args == ["hello", "world"]
+    assert Config.cli_args(config) == ["hello", "world"]
   end
 
   test "new/1 default cli_args to empty list" do
     config = Config.new()
-    assert config.cli_args == []
+    assert Config.cli_args(config) == []
   end
 
   test "new/1 takes :clear from the env" do

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -4,73 +4,104 @@ defmodule MixTestInteractive.ConfigTest do
 
   alias MixTestInteractive.Config
 
-  test "new/1 takes :tasks from the env" do
-    TemporaryEnv.put :mix_test_interactive, :tasks, :env_tasks do
+  describe "creation" do
+    test "takes :tasks from the env" do
+      TemporaryEnv.put :mix_test_interactive, :tasks, :env_tasks do
+        config = Config.new()
+        assert config.tasks == :env_tasks
+      end
+    end
+
+    test ~s(defaults :tasks to ["test"]) do
+      TemporaryEnv.delete :mix_test_interactive, :tasks do
+        config = Config.new()
+        assert config.tasks == ["test"]
+      end
+    end
+
+    test "takes :exclude from the env" do
+      TemporaryEnv.put :mix_test_interactive, :exclude, [~r/migration_.*/] do
+        config = Config.new()
+        assert config.exclude == [~r/migration_.*/]
+      end
+    end
+
+    test ":exclude contains common editor temp/swap files by default" do
       config = Config.new()
-      assert config.tasks == :env_tasks
+      # Emacs lock symlink
+      assert ~r/\.#/ in config.exclude
+    end
+
+    test "excludes default Phoenix migrations directory by default" do
+      config = Config.new()
+      assert ~r{priv/repo/migrations} in config.exclude
+    end
+
+    test "takes :extra_extensions from the env" do
+      TemporaryEnv.put :mix_test_interactive, :extra_extensions, [".haml"] do
+        config = Config.new()
+        assert config.extra_extensions == [".haml"]
+      end
+    end
+
+    test "passes cli_args" do
+      config = Config.new(["hello", "world"])
+      assert Config.cli_args(config) == ["hello", "world"]
+    end
+
+    test "default cli_args to empty list" do
+      config = Config.new()
+      assert Config.cli_args(config) == []
+    end
+
+    test "takes :clear from the env" do
+      TemporaryEnv.put :mix_test_interactive, :clear, true do
+        config = Config.new()
+        assert config.clear
+      end
+    end
+
+    test "takes :timestamp from the env" do
+      TemporaryEnv.put :mix_test_interactive, :timestamp, true do
+        config = Config.new()
+        assert config.timestamp
+      end
+    end
+
+    test "takes :shell_prefix from the env" do
+      TemporaryEnv.put :mix_test_interactive, :cli_executable, "iex -S" do
+        config = Config.new()
+        assert config.cli_executable == "iex -S"
+      end
     end
   end
 
-  test ~s(new/1 defaults :tasks to ["test"]) do
-    TemporaryEnv.delete :mix_test_interactive, :tasks do
-      config = Config.new()
-      assert config.tasks == ["test"]
+  describe "command line arguments" do
+    test "passes on provided arguments" do
+      config = Config.new(["hello", "world"])
+      assert Config.cli_args(config) == ["hello", "world"]
     end
-  end
 
-  test "new/1 takes :exclude from the env" do
-    TemporaryEnv.put :mix_test_interactive, :exclude, [~r/migration_.*/] do
+    test "passes no arguments by default" do
       config = Config.new()
-      assert config.exclude == [~r/migration_.*/]
+      assert Config.cli_args(config) == []
     end
-  end
 
-  test ":exclude contains common editor temp/swap files by default" do
-    config = Config.new()
-    # Emacs lock symlink
-    assert ~r/\.#/ in config.exclude
-  end
+    test "restricts to provided files" do
+      config =
+        Config.new(["provided"])
+        |> Config.only_files(["file1", "file2:42"])
 
-  test ":exclude contains default Phoenix migrations directory by default" do
-    config = Config.new()
-    assert ~r{priv/repo/migrations} in config.exclude
-  end
-
-  test "new/1 takes :extra_extensions from the env" do
-    TemporaryEnv.put :mix_test_interactive, :extra_extensions, [".haml"] do
-      config = Config.new()
-      assert config.extra_extensions == [".haml"]
+      assert Config.cli_args(config) == ["provided", "file1", "file2:42"]
     end
-  end
 
-  test "new/1 passes cli_args" do
-    config = Config.new(["hello", "world"])
-    assert Config.cli_args(config) == ["hello", "world"]
-  end
+    test "clears restricted files" do
+      config =
+        Config.new()
+        |> Config.only_files(["restricted"])
+        |> Config.all_files()
 
-  test "new/1 default cli_args to empty list" do
-    config = Config.new()
-    assert Config.cli_args(config) == []
-  end
-
-  test "new/1 takes :clear from the env" do
-    TemporaryEnv.put :mix_test_interactive, :clear, true do
-      config = Config.new()
-      assert config.clear
-    end
-  end
-
-  test "new/1 takes :timestamp from the env" do
-    TemporaryEnv.put :mix_test_interactive, :timestamp, true do
-      config = Config.new()
-      assert config.timestamp
-    end
-  end
-
-  test "new/1 takes :shell_prefix from the env" do
-    TemporaryEnv.put :mix_test_interactive, :cli_executable, "iex -S" do
-      config = Config.new()
-      assert config.cli_executable == "iex -S"
+      assert Config.cli_args(config) == []
     end
   end
 end

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -5,7 +5,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
   describe "build_tasks_cmds/1" do
     test "appends commandline arguments from passed config" do
-      config = %Config{cli_args: ["--exclude", "integration"]}
+      config = Config.new(["--exclude", "integration"])
 
       expected =
         "MIX_ENV=test mix do run -e " <>
@@ -25,7 +25,7 @@ defmodule MixTestInteractive.PortRunnerTest do
     end
 
     test "respect no-start commandline argument from passed config" do
-      config = %Config{cli_args: ["--exclude", "integration", "--no-start"]}
+      config = Config.new(["--exclude", "integration", "--no-start"])
 
       expected =
         "MIX_ENV=test mix do run --no-start -e " <>

--- a/test/mix_test_interactive_test.exs
+++ b/test/mix_test_interactive_test.exs
@@ -1,3 +1,0 @@
-defmodule MixTestInteractiveTest do
-  use ExUnit.Case
-end


### PR DESCRIPTION
New `p` command takes a list of files (or file:line specs) and runs only those files.

`c` command clears the filename filter.