### PR TITLE
✨ Add stale command

### DIFF
--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -19,17 +19,27 @@ defmodule MixTestInteractive.CommandProcessor do
     Usage
     › p <files> to run only the specified test files.
     › c to clear any file filters.
+    › s to run only stale files.
+    › a to run all files.
     › Enter to trigger a test run.
     › q to quit.
     """
+  end
+
+  defp process_command("a", _args, config) do
+    {:ok, Config.clear_flags(config)}
+  end
+
+  defp process_command("c", _args, config) do
+    {:ok, Config.clear_filters(config)}
   end
 
   defp process_command("p", files, config) do
     {:ok, Config.only_files(config, files)}
   end
 
-  defp process_command("c", _args, config) do
-    {:ok, Config.all_files(config)}
+  defp process_command("s", _args, config) do
+    {:ok, Config.only_stale(config)}
   end
 
   defp process_command("q", _args, _config), do: :quit

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -19,6 +19,7 @@ defmodule MixTestInteractive.Config do
             files: [],
             initial_cli_args: [],
             runner: @default_runner,
+            stale?: false,
             tasks: @default_tasks,
             timestamp: @default_timestamp
 
@@ -32,7 +33,6 @@ defmodule MixTestInteractive.Config do
       cli_executable: get_cli_executable(),
       exclude: get_excluded(),
       extra_extensions: get_extra_extensions(),
-      files: [],
       initial_cli_args: cli_args,
       runner: get_runner(),
       tasks: get_tasks(),
@@ -40,14 +40,32 @@ defmodule MixTestInteractive.Config do
     }
   end
 
-  def cli_args(%__MODULE__{files: files, initial_cli_args: cli_args}), do: cli_args ++ files
+  def cli_args(%__MODULE__{initial_cli_args: initial_args} = config) do
+    initial_args ++ args_from_settings(config)
+  end
 
-  def all_files(config) do
+  def clear_filters(config) do
     %{config | files: []}
   end
 
   def only_files(config, files) do
     %{config | files: files}
+  end
+
+  def only_stale(config) do
+    %{config | stale?: true}
+  end
+
+  def clear_flags(config) do
+    %{config | stale?: false}
+  end
+
+  defp args_from_settings(%__MODULE__{files: files, stale?: stale?}) do
+    if stale? do
+      ["--stale" | files]
+    else
+      files
+    end
   end
 
   defp get_runner do

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -21,7 +21,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^config} = process_command("", config)
     end
 
-    test "p restricts files to provided list" do
+    test "p filters files to provided list" do
       config = Config.new()
       files = ["file1", "file2"]
       expected = Config.only_files(config, files)
@@ -29,11 +29,25 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^expected} = process_command("p file1 file2")
     end
 
-    test "c clears file restrictions" do
-      config = Config.new() |> Config.only_files("file")
-      expected = Config.all_files(config)
+    test "c clears file filters" do
+      {:ok, config} = process_command("p file", Config.new())
+      expected = Config.clear_filters(config)
 
       assert {:ok, ^expected} = process_command("c")
+    end
+
+    test "s runs only stale files" do
+      config = Config.new()
+      expected = Config.only_stale(config)
+
+      assert {:ok, ^expected} = process_command("s")
+    end
+
+    test "a runs all files" do
+      {:ok, config} = process_command("s", Config.new())
+      expected = Config.clear_flags(config)
+
+      assert {:ok, ^expected} = process_command("a")
     end
 
     test "trims whitespace from commands" do
@@ -47,6 +61,8 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert usage =~ ~r/^Usage/
       assert usage =~ ~r/^› p/m
       assert usage =~ ~r/^› c/m
+      assert usage =~ ~r/^› s/m
+      assert usage =~ ~r/^› a/m
       assert usage =~ ~r/^› Enter/m
       assert usage =~ ~r/^› q/m
     end

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -87,7 +87,7 @@ defmodule MixTestInteractive.ConfigTest do
       assert Config.cli_args(config) == []
     end
 
-    test "restricts to provided files" do
+    test "filters to provided files" do
       config =
         Config.new(["provided"])
         |> Config.only_files(["file1", "file2:42"])
@@ -95,13 +95,49 @@ defmodule MixTestInteractive.ConfigTest do
       assert Config.cli_args(config) == ["provided", "file1", "file2:42"]
     end
 
-    test "clears restricted files" do
+    test "clears file filters" do
       config =
         Config.new()
         |> Config.only_files(["restricted"])
-        |> Config.all_files()
+        |> Config.clear_filters()
 
       assert Config.cli_args(config) == []
+    end
+
+    test "restricts to stale files" do
+      config =
+        Config.new(["provided"])
+        |> Config.only_stale()
+
+      assert Config.cli_args(config) == ["provided", "--stale"]
+    end
+
+    test "stale flag retains file filters" do
+      config =
+        Config.new()
+        |> Config.only_files(["file"])
+        |> Config.only_stale()
+
+      assert Config.cli_args(config) == ["--stale", "file"]
+    end
+
+    test "removes stale flag" do
+      config =
+        Config.new()
+        |> Config.only_stale()
+        |> Config.clear_flags()
+
+      assert Config.cli_args(config) == []
+    end
+
+    test "removing stale flag retains file filters" do
+      config =
+        Config.new()
+        |> Config.only_files(["file"])
+        |> Config.only_stale()
+        |> Config.clear_flags()
+
+      assert Config.cli_args(config) == ["file"]
     end
   end
 end


### PR DESCRIPTION
`s` restricts to stale files; `a` returns to running all files

Both commands retain any filename filters previously set.