### PR TITLE
✨ Add command to run only failed tests

### DIFF
--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -19,8 +19,9 @@ defmodule MixTestInteractive.CommandProcessor do
     Usage
     › p <files> to run only the specified test files.
     › c to clear any file filters.
-    › s to run only stale files.
-    › a to run all files.
+    › s to run only stale tests.
+    › f to run only failed tests.
+    › a to run all (filtered) tests.
     › Enter to trigger a test run.
     › q to quit.
     """
@@ -32,6 +33,10 @@ defmodule MixTestInteractive.CommandProcessor do
 
   defp process_command("c", _args, config) do
     {:ok, Config.clear_filters(config)}
+  end
+
+  defp process_command("f", _args, config) do
+    {:ok, Config.only_failed(config)}
   end
 
   defp process_command("p", files, config) do

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -16,6 +16,7 @@ defmodule MixTestInteractive.Config do
             cli_executable: @default_cli_executable,
             exclude: @default_exclude,
             extra_extensions: @default_extra_extensions,
+            failed?: false,
             files: [],
             initial_cli_args: [],
             runner: @default_runner,
@@ -44,12 +45,16 @@ defmodule MixTestInteractive.Config do
     initial_args ++ args_from_settings(config)
   end
 
+  def only_files(config, files) do
+    %{config | files: files}
+  end
+
   def clear_filters(config) do
     %{config | files: []}
   end
 
-  def only_files(config, files) do
-    %{config | files: files}
+  def only_failed(config) do
+    %{config | failed?: true}
   end
 
   def only_stale(config) do
@@ -57,7 +62,12 @@ defmodule MixTestInteractive.Config do
   end
 
   def clear_flags(config) do
-    %{config | stale?: false}
+    %{config | failed?: false, stale?: false}
+  end
+
+  defp args_from_settings(%__MODULE__{failed?: true}) do
+    # --failed doesn't work with --stale or with any filenames
+    ["--failed"]
   end
 
   defp args_from_settings(%__MODULE__{files: files, stale?: stale?}) do

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -26,28 +26,35 @@ defmodule MixTestInteractive.CommandProcessorTest do
       files = ["file1", "file2"]
       expected = Config.only_files(config, files)
 
-      assert {:ok, ^expected} = process_command("p file1 file2")
+      assert {:ok, ^expected} = process_command("p file1 file2", config)
     end
 
     test "c clears file filters" do
       {:ok, config} = process_command("p file", Config.new())
       expected = Config.clear_filters(config)
 
-      assert {:ok, ^expected} = process_command("c")
+      assert {:ok, ^expected} = process_command("c", config)
     end
 
     test "s runs only stale files" do
       config = Config.new()
       expected = Config.only_stale(config)
 
-      assert {:ok, ^expected} = process_command("s")
+      assert {:ok, ^expected} = process_command("s", config)
+    end
+
+    test "f runs only failed files" do
+      config = Config.new()
+      expected = Config.only_failed(config)
+
+      assert {:ok, ^expected} = process_command("f", config)
     end
 
     test "a runs all files" do
       {:ok, config} = process_command("s", Config.new())
       expected = Config.clear_flags(config)
 
-      assert {:ok, ^expected} = process_command("a")
+      assert {:ok, ^expected} = process_command("a", config)
     end
 
     test "trims whitespace from commands" do
@@ -62,6 +69,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert usage =~ ~r/^› p/m
       assert usage =~ ~r/^› c/m
       assert usage =~ ~r/^› s/m
+      assert usage =~ ~r/^› f/m
       assert usage =~ ~r/^› a/m
       assert usage =~ ~r/^› Enter/m
       assert usage =~ ~r/^› q/m

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -121,7 +121,7 @@ defmodule MixTestInteractive.ConfigTest do
       assert Config.cli_args(config) == ["--stale", "file"]
     end
 
-    test "removes stale flag" do
+    test "clearing flags removes stale flag" do
       config =
         Config.new()
         |> Config.only_stale()
@@ -130,11 +130,39 @@ defmodule MixTestInteractive.ConfigTest do
       assert Config.cli_args(config) == []
     end
 
-    test "removing stale flag retains file filters" do
+    test "restricts to failed files" do
+      config =
+        Config.new(["provided"])
+        |> Config.only_failed()
+
+      assert Config.cli_args(config) == ["provided", "--failed"]
+    end
+
+    test "failed flag omits stale flag and files" do
       config =
         Config.new()
         |> Config.only_files(["file"])
         |> Config.only_stale()
+        |> Config.only_failed()
+
+      assert Config.cli_args(config) == ["--failed"]
+    end
+
+    test "clearing flags clears failed flag" do
+      config =
+        Config.new()
+        |> Config.only_failed()
+        |> Config.clear_flags()
+
+      assert Config.cli_args(config) == []
+    end
+
+    test "clearing flags retains file filters" do
+      config =
+        Config.new()
+        |> Config.only_files(["file"])
+        |> Config.only_stale()
+        |> Config.only_failed()
         |> Config.clear_flags()
 
       assert Config.cli_args(config) == ["file"]


### PR DESCRIPTION
`f` will run only failed tests; `a` will go back to running all tests.