### PR TITLE
✨ Show only relevant commands in usage

### DIFF
--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -24,9 +24,10 @@ defmodule MixTestInteractive.CommandProcessor do
     end
   end
 
-  def usage do
+  def usage(config) do
     usage =
-      @commands
+      config
+      |> applicable_commands()
       |> Enum.map(&usage_line/1)
       |> Enum.join("\n")
 

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -2,8 +2,18 @@ defmodule MixTestInteractive.CommandProcessor do
   @moduledoc false
 
   alias MixTestInteractive.Config
+  alias MixTestInteractive.Command.{AllTests, Failed, FilterPaths, Quit, RunTests, Stale}
 
   @spec call(String.t() | :eof, Config.t()) :: {:ok, Config.t()} | :unknown | :quit
+
+  @commands [
+    FilterPaths,
+    Stale,
+    Failed,
+    AllTests,
+    RunTests,
+    Quit
+  ]
 
   def call(:eof, _config), do: :quit
 
@@ -15,34 +25,28 @@ defmodule MixTestInteractive.CommandProcessor do
   end
 
   def usage do
-    """
-    Usage
-    › p <files> to run only the specified test files.
-    › s to run only stale tests.
-    › f to run only failed tests.
-    › a to run all tests.
-    › Enter to trigger a test run.
-    › q to quit.
-    """
+    usage =
+      @commands
+      |> Enum.map(&usage_line/1)
+      |> Enum.join("\n")
+
+    "Usage\n" <> usage
   end
 
-  defp process_command("a", _args, config) do
-    {:ok, Config.all_tests(config)}
+  defp usage_line(command) do
+    "› #{command.name} to #{command.description}."
   end
 
-  defp process_command("f", _args, config) do
-    {:ok, Config.only_failed(config)}
+  defp process_command(command, args, config) do
+    case config
+         |> applicable_commands()
+         |> Enum.find(nil, &(&1.command == command)) do
+      nil -> :unknown
+      cmd -> cmd.run(args, config)
+    end
   end
 
-  defp process_command("p", files, config) do
-    {:ok, Config.only_files(config, files)}
+  defp applicable_commands(config) do
+    Enum.filter(@commands, & &1.applies?(config))
   end
-
-  defp process_command("s", _args, config) do
-    {:ok, Config.only_stale(config)}
-  end
-
-  defp process_command("q", _args, _config), do: :quit
-  defp process_command("", _args, config), do: {:ok, config}
-  defp process_command(_unknown_command, _args, _config), do: :unknown
 end

--- a/lib/mix_test_interactive/commands.ex
+++ b/lib/mix_test_interactive/commands.ex
@@ -1,0 +1,120 @@
+defmodule MixTestInteractive.Command do
+  alias MixTestInteractive.Config
+
+  @type response :: {:ok, Config.t()} | :quit | :unknown
+
+  @callback applies?(Config.t()) :: boolean()
+  @callback description :: String.t()
+  @callback command :: String.t()
+  @callback name :: String.t()
+  @callback run([String.t()], Config.t()) :: response()
+
+  defmacro __using__(opts) do
+    description = Keyword.fetch!(opts, :desc)
+    command = Keyword.fetch!(opts, :command)
+
+    quote do
+      @behaviour MixTestInteractive.Command
+
+      @impl true
+      def applies?(_config), do: true
+
+      @impl true
+      def description, do: unquote(description)
+
+      @impl true
+      def command, do: unquote(command)
+
+      @impl true
+      def name, do: unquote(command)
+
+      defoverridable applies?: 1, name: 0
+    end
+  end
+end
+
+defmodule MixTestInteractive.Command.FilterPaths do
+  alias MixTestInteractive.{Command, Config}
+
+  use Command, command: "p", desc: "run only the specified test files"
+
+  @impl Command
+  def applies?(%Config{files: []}), do: true
+  def applies?(_config), do: false
+
+  @impl Command
+  def name, do: "p <files>"
+
+  @impl Command
+  def run(files, config) do
+    {:ok, Config.only_files(config, files)}
+  end
+end
+
+defmodule MixTestInteractive.Command.Stale do
+  alias MixTestInteractive.{Command, Config}
+
+  use Command, command: "s", desc: "run only stale tests"
+
+  @impl Command
+  def applies?(%Config{stale?: false}), do: true
+  def applies?(_config), do: false
+
+  @impl Command
+  def run(_args, config) do
+    {:ok, Config.only_stale(config)}
+  end
+end
+
+defmodule MixTestInteractive.Command.Failed do
+  alias MixTestInteractive.{Command, Config}
+
+  use Command, command: "f", desc: "run only failed tests"
+
+  @impl Command
+  def applies?(%Config{failed?: false}), do: true
+  def applies?(_config), do: false
+
+  @impl Command
+  def run(_args, config) do
+    {:ok, Config.only_failed(config)}
+  end
+end
+
+defmodule MixTestInteractive.Command.AllTests do
+  alias MixTestInteractive.{Command, Config}
+
+  use Command, command: "a", desc: "run all tests"
+
+  @impl Command
+  def applies?(%Config{failed?: true}), do: true
+  def applies?(%Config{files: [_h | _t]}), do: true
+  def applies?(%Config{stale?: true}), do: true
+  def applies?(_config), do: false
+
+  @impl Command
+  def run(_args, config) do
+    {:ok, Config.all_tests(config)}
+  end
+end
+
+defmodule MixTestInteractive.Command.Quit do
+  alias MixTestInteractive.Command
+
+  use Command, command: "q", desc: "quit"
+
+  @impl Command
+  def run(_args, _config), do: :quit
+end
+
+defmodule MixTestInteractive.Command.RunTests do
+  alias MixTestInteractive.Command
+
+  use Command, command: "", desc: "trigger a test run"
+
+  @impl Command
+  def name, do: "Enter"
+
+  @impl Command
+  def run(_args, config), do: {:ok, config}
+end

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -10,7 +10,7 @@ defmodule MixTestInteractive.InteractiveMode do
   def run_tests(config) do
     Runner.run(config)
     show_summary(config)
-    show_usage()
+    show_usage(config)
   end
 
   defp loop(config) do
@@ -38,8 +38,8 @@ defmodule MixTestInteractive.InteractiveMode do
     |> IO.puts()
   end
 
-  defp show_usage() do
+  defp show_usage(config) do
     IO.puts("")
-    IO.puts(CommandProcessor.usage())
+    IO.puts(CommandProcessor.usage(config))
   end
 end

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -56,15 +56,48 @@ defmodule MixTestInteractive.CommandProcessorTest do
   end
 
   describe "usage information" do
-    test "usage describes all commands" do
-      usage = CommandProcessor.usage()
+    test "shows relevant commands when running all tests" do
+      config = Config.new()
+
+      assert_commands(config, ~w(p s f Enter q), ~w(a))
+    end
+
+    test "shows relevant commands when running specific files" do
+      config =
+        Config.new()
+        |> Config.only_files(["file"])
+
+      assert_commands(config, ~w(s f a Enter q), ~w(p))
+    end
+
+    test "shows relevant commands when running failed tests" do
+      config =
+        Config.new()
+        |> Config.only_failed()
+
+      assert_commands(config, ~w(p s a Enter q), ~w(f))
+    end
+
+    test "shows relevant commands when running stale tests" do
+      config =
+        Config.new()
+        |> Config.only_stale()
+
+      assert_commands(config, ~w(p f a Enter q), ~w(s))
+    end
+
+    defp assert_commands(config, included, excluded) do
+      usage = CommandProcessor.usage(config)
+
       assert usage =~ ~r/^Usage/
-      assert usage =~ ~r/^› p/m
-      assert usage =~ ~r/^› s/m
-      assert usage =~ ~r/^› f/m
-      assert usage =~ ~r/^› a/m
-      assert usage =~ ~r/^› Enter/m
-      assert usage =~ ~r/^› q/m
+
+      for command <- included do
+        assert usage =~ ~r/^› #{command}/m
+      end
+
+      for command <- excluded do
+        refute usage =~ ~r/^› #{command}/m
+      end
     end
   end
 end


### PR DESCRIPTION
Extracts commands to their own modules and use them to only run relevant commands and show them in the usage message.