### PR TITLE
✨ Only show full usage when asked

### DIFF
--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -2,9 +2,10 @@ defmodule MixTestInteractive.CommandProcessor do
   @moduledoc false
 
   alias MixTestInteractive.Config
-  alias MixTestInteractive.Command.{AllTests, Failed, FilterPaths, Quit, RunTests, Stale}
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Command.{AllTests, Failed, FilterPaths, Help, Quit, RunTests, Stale}
 
-  @spec call(String.t() | :eof, Config.t()) :: {:ok, Config.t()} | :unknown | :quit
+  @spec call(String.t() | :eof, Config.t()) :: Command.response()
 
   @commands [
     FilterPaths,
@@ -12,6 +13,7 @@ defmodule MixTestInteractive.CommandProcessor do
     Failed,
     AllTests,
     RunTests,
+    Help,
     Quit
   ]
 
@@ -31,7 +33,7 @@ defmodule MixTestInteractive.CommandProcessor do
       |> Enum.map(&usage_line/1)
       |> Enum.join("\n")
 
-    "Usage\n" <> usage
+    "Usage:\n" <> usage
   end
 
   defp usage_line(command) do

--- a/lib/mix_test_interactive/commands.ex
+++ b/lib/mix_test_interactive/commands.ex
@@ -1,7 +1,7 @@
 defmodule MixTestInteractive.Command do
   alias MixTestInteractive.Config
 
-  @type response :: {:ok, Config.t()} | :quit | :unknown
+  @type response :: {:ok, Config.t()} | :help | :quit | :unknown
 
   @callback applies?(Config.t()) :: boolean()
   @callback description :: String.t()
@@ -96,6 +96,15 @@ defmodule MixTestInteractive.Command.AllTests do
   def run(_args, config) do
     {:ok, Config.all_tests(config)}
   end
+end
+
+defmodule MixTestInteractive.Command.Help do
+  alias MixTestInteractive.Command
+
+  use Command, command: "?", desc: "show help"
+
+  @impl Command
+  def run(_args, _config), do: :help
 end
 
 defmodule MixTestInteractive.Command.Quit do

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -10,7 +10,7 @@ defmodule MixTestInteractive.InteractiveMode do
   def run_tests(config) do
     Runner.run(config)
     show_summary(config)
-    show_usage(config)
+    show_usage_prompt()
   end
 
   defp loop(config) do
@@ -21,6 +21,10 @@ defmodule MixTestInteractive.InteractiveMode do
         ConfigStore.store(new_config)
         run_tests(new_config)
         loop(new_config)
+
+      :help ->
+        show_help(config)
+        loop(config)
 
       :unknown ->
         loop(config)
@@ -38,8 +42,16 @@ defmodule MixTestInteractive.InteractiveMode do
     |> IO.puts()
   end
 
-  defp show_usage(config) do
+  defp show_usage_prompt() do
     IO.puts("")
-    IO.puts(CommandProcessor.usage(config))
+    IO.puts("Usage: ? to show more")
+  end
+
+  defp show_help(config) do
+    IO.puts("")
+
+    config
+    |> CommandProcessor.usage()
+    |> IO.puts()
   end
 end

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -50,6 +50,12 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^expected} = process_command("a", config)
     end
 
+    test "? returns :help" do
+      config = Config.new()
+
+      assert :help = process_command("?", config)
+    end
+
     test "trims whitespace from commands" do
       assert :quit = process_command("\t  q   \n   \t")
     end
@@ -59,7 +65,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
     test "shows relevant commands when running all tests" do
       config = Config.new()
 
-      assert_commands(config, ~w(p s f Enter q), ~w(a))
+      assert_commands(config, ~w(p s f), ~w(a))
     end
 
     test "shows relevant commands when running specific files" do
@@ -67,7 +73,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
         Config.new()
         |> Config.only_files(["file"])
 
-      assert_commands(config, ~w(s f a Enter q), ~w(p))
+      assert_commands(config, ~w(s f a), ~w(p))
     end
 
     test "shows relevant commands when running failed tests" do
@@ -75,7 +81,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
         Config.new()
         |> Config.only_failed()
 
-      assert_commands(config, ~w(p s a Enter q), ~w(f))
+      assert_commands(config, ~w(p s a), ~w(f))
     end
 
     test "shows relevant commands when running stale tests" do
@@ -83,13 +89,14 @@ defmodule MixTestInteractive.CommandProcessorTest do
         Config.new()
         |> Config.only_stale()
 
-      assert_commands(config, ~w(p f a Enter q), ~w(s))
+      assert_commands(config, ~w(p f a), ~w(s))
     end
 
     defp assert_commands(config, included, excluded) do
+      included = included ++ ~w(Enter ? q)
       usage = CommandProcessor.usage(config)
 
-      assert usage =~ ~r/^Usage/
+      assert usage =~ ~r/^Usage:/
 
       for command <- included do
         assert usage =~ ~r/^› #{command}/m


### PR DESCRIPTION
Preserve output space by normally showing a short usage message.

Adds a `?` command to show the full usage message.