### PR TITLE
🐛 Allow consecutive p commands

### DIFF
--- a/lib/mix_test_interactive/command/pattern.ex
+++ b/lib/mix_test_interactive/command/pattern.ex
@@ -4,10 +4,6 @@ defmodule MixTestInteractive.Command.Pattern do
   use Command, command: "p", desc: "run only test files matching pattern(s)"
 
   @impl Command
-  def applies?(%Config{patterns: []}), do: true
-  def applies?(_config), do: false
-
-  @impl Command
   def name, do: "p <patterns>"
 
   @impl Command

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -28,6 +28,14 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^expected} = process_command("p pattern", config)
     end
 
+    test "p a second time replaces patterns with new ones" do
+      config = Config.new()
+      {:ok, first_config} = process_command("p first", Config.new())
+      expected = Config.only_patterns(config, ["second"])
+
+      assert {:ok, ^expected} = process_command("p second", first_config)
+    end
+
     test "s runs only stale tests" do
       config = Config.new()
       expected = Config.only_stale(config)
@@ -72,7 +80,7 @@ defmodule MixTestInteractive.CommandProcessorTest do
         Config.new()
         |> Config.only_patterns(["pattern"])
 
-      assert_commands(config, ~w(s f a), ~w(p))
+      assert_commands(config, ["p <patterns>", "s", "f", "a"], ~w(p))
     end
 
     test "shows relevant commands when running failed tests" do


### PR DESCRIPTION
We want to allow changing to a different pattern without having to switch back to s, f, or a mode first.