### PR TITLE
✨ Show failure message when no tests match

### DIFF
--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -3,12 +3,12 @@ defmodule MixTestInteractive.InteractiveMode do
 
   def start(config) do
     ConfigStore.store(config)
-    run_tests(config)
+    run(config)
     loop(config)
   end
 
-  def run_tests(config) do
-    Runner.run(config)
+  def run(config) do
+    :ok = run_tests(config)
     show_summary(config)
     show_usage_prompt()
   end
@@ -19,7 +19,7 @@ defmodule MixTestInteractive.InteractiveMode do
     case CommandProcessor.call(command, config) do
       {:ok, new_config} ->
         ConfigStore.store(new_config)
-        run_tests(new_config)
+        run(new_config)
         loop(new_config)
 
       :help ->
@@ -31,6 +31,22 @@ defmodule MixTestInteractive.InteractiveMode do
 
       :quit ->
         :ok
+    end
+  end
+
+  defp run_tests(config) do
+    with :ok <- Runner.run(config) do
+      :ok
+    else
+      {:error, :no_matching_files} ->
+        [:red, "No matching tests found"]
+        |> IO.ANSI.format()
+        |> IO.puts()
+
+        :ok
+
+      error ->
+        error
     end
   end
 

--- a/lib/mix_test_interactive/runner.ex
+++ b/lib/mix_test_interactive/runner.ex
@@ -6,7 +6,7 @@ defmodule MixTestInteractive.Runner do
   @doc """
   Run tests using provided runner.
   """
-  @spec run(Config.t()) :: :ok
+  @spec run(Config.t()) :: :ok | {:error, term()}
   def run(config) do
     :ok = maybe_clear_terminal(config)
     IO.puts("\nRunning tests...")

--- a/lib/mix_test_interactive/watcher.ex
+++ b/lib/mix_test_interactive/watcher.ex
@@ -37,7 +37,7 @@ defmodule MixTestInteractive.Watcher do
     path = to_string(path)
 
     if Paths.watching?(path, config) do
-      InteractiveMode.run_tests(config)
+      InteractiveMode.run(config)
       MessageInbox.flush()
     end
 

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -69,12 +69,14 @@ defmodule MixTestInteractive.ConfigTest do
   describe "command line arguments" do
     test "passes on provided arguments" do
       config = Config.new(["hello", "world"])
-      assert Config.cli_args(config) == ["hello", "world"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["hello", "world"]
     end
 
     test "passes no arguments by default" do
       config = Config.new()
-      assert Config.cli_args(config) == []
+      {:ok, args} = Config.cli_args(config)
+      assert args == []
     end
 
     test "initializes stale flag from arguments" do
@@ -99,7 +101,17 @@ defmodule MixTestInteractive.ConfigTest do
         |> with_fake_file_list(all_files)
         |> Config.only_patterns(["file", "other"])
 
-      assert Config.cli_args(config) == ["provided", "file1", "file2", "other"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["provided", "file1", "file2", "other"]
+    end
+
+    test "returns error if no files match pattern" do
+      config =
+        Config.new()
+        |> with_fake_file_list([])
+        |> Config.only_patterns(["file"])
+
+      assert {:error, :no_matching_files} = Config.cli_args(config)
     end
 
     test "restricts to failed tests" do
@@ -107,7 +119,8 @@ defmodule MixTestInteractive.ConfigTest do
         Config.new(["provided"])
         |> Config.only_failed()
 
-      assert Config.cli_args(config) == ["provided", "--failed"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["provided", "--failed"]
     end
 
     test "restricts to stale tests" do
@@ -115,7 +128,8 @@ defmodule MixTestInteractive.ConfigTest do
         Config.new(["provided"])
         |> Config.only_stale()
 
-      assert Config.cli_args(config) == ["provided", "--stale"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["provided", "--stale"]
     end
 
     test "pattern filter clears failed flag" do
@@ -125,7 +139,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_failed()
         |> Config.only_patterns(["f"])
 
-      assert Config.cli_args(config) == ["file"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["file"]
     end
 
     test "pattern filter clears stale flag" do
@@ -135,7 +150,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_stale()
         |> Config.only_patterns(["f"])
 
-      assert Config.cli_args(config) == ["file"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["file"]
     end
 
     test "failed flag clears pattern filters" do
@@ -144,7 +160,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_patterns(["file"])
         |> Config.only_failed()
 
-      assert Config.cli_args(config) == ["--failed"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["--failed"]
     end
 
     test "failed flag clears stale flag" do
@@ -153,7 +170,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_stale()
         |> Config.only_failed()
 
-      assert Config.cli_args(config) == ["--failed"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["--failed"]
     end
 
     test "stale flag clears pattern filters" do
@@ -162,7 +180,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_patterns(["file"])
         |> Config.only_stale()
 
-      assert Config.cli_args(config) == ["--stale"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["--stale"]
     end
 
     test "stale flag clears failed flag" do
@@ -171,7 +190,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_failed()
         |> Config.only_stale()
 
-      assert Config.cli_args(config) == ["--stale"]
+      {:ok, args} = Config.cli_args(config)
+      assert args == ["--stale"]
     end
 
     test "all tests clears pattern filters" do
@@ -180,7 +200,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_patterns(["pattern"])
         |> Config.all_tests()
 
-      assert Config.cli_args(config) == []
+      {:ok, args} = Config.cli_args(config)
+      assert args == []
     end
 
     test "all tests removes stale flag" do
@@ -189,7 +210,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_stale()
         |> Config.all_tests()
 
-      assert Config.cli_args(config) == []
+      {:ok, args} = Config.cli_args(config)
+      assert args == []
     end
 
     test "all tests removes failed flag" do
@@ -198,7 +220,8 @@ defmodule MixTestInteractive.ConfigTest do
         |> Config.only_failed()
         |> Config.all_tests()
 
-      assert Config.cli_args(config) == []
+      {:ok, args} = Config.cli_args(config)
+      assert args == []
     end
 
     defp with_fake_file_list(config, files) do

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -11,7 +11,7 @@ defmodule MixTestInteractive.PortRunnerTest do
         "MIX_ENV=test mix do run -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
 
-      assert PortRunner.build_tasks_cmds(config) == expected
+      assert {:ok, ^expected} = PortRunner.build_tasks_cmds(config)
     end
 
     test "take the command cli_executable from passed config" do
@@ -21,7 +21,7 @@ defmodule MixTestInteractive.PortRunnerTest do
         "MIX_ENV=test iex -S mix do run -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', test"
 
-      assert PortRunner.build_tasks_cmds(config) == expected
+      assert {:ok, ^expected} = PortRunner.build_tasks_cmds(config)
     end
 
     test "respect no-start commandline argument from passed config" do
@@ -32,7 +32,7 @@ defmodule MixTestInteractive.PortRunnerTest do
           "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
           "test --exclude integration --no-start"
 
-      assert PortRunner.build_tasks_cmds(config) == expected
+      assert {:ok, ^expected} = PortRunner.build_tasks_cmds(config)
     end
   end
 end


### PR DESCRIPTION
When no tests match a given pattern, we would instead run all tests.

Now, we show a message indicating that no tests were found.