### PR TITLE
🔥 Remove some config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,9 @@ Use the `Enter` key to re-run the current set of tests without requiring a file 
 
 Use the `q` command, or press `Ctrl-D` to exit the program.
 
-## Running Additional Mix Tasks
+## Running A Different Mix Task
 
-Through the mix config it is possible to run other mix tasks as well as the
-test task. For example, if I wished to run the [Dogma][dogma] code style
-linter after my tests I would do so like this.
-
-[dogma]: https://github.com/lpil/dogma
+By default, `mix test.interactive` runs `mix test`. Through the mix config it is possible to run a different mix task. `mix test.interactive` assumes that this alternative task accepts the same command-line arguments as `mix test`.
 
 ```elixir
 # config/config.exs
@@ -60,17 +56,11 @@ use Mix.Config
 
 if Mix.env == :dev do
   config :mix_test_interactive,
-    tasks: [
-      "test",
-      "dogma",
-    ]
+    task: "custom_test_task"
 end
 ```
 
-Tasks are run in the order they appear in the list, and the progression will
-stop if any command returns a non-zero exit code.
-
-All tasks are run with `MIX_ENV` set to `test`.
+The task is run with `MIX_ENV` set to `test`.
 
 ## Passing Arguments To Tasks
 
@@ -80,9 +70,6 @@ through to all of the tasks being run, along with any arguments added by interac
 ```
 mix test.interactive --trace
 ```
-
-Note that if you have configured more than one task to be run, these arguments
-will be passed to all the tasks run, not just the test command.
 
 `mix test.interactive` will detect the `--stale` and `--failed` arguments and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed.
 

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -8,16 +8,14 @@ defmodule MixTestInteractive.Config do
   @application :mix_test_interactive
 
   @default_runner MixTestInteractive.PortRunner
-  @default_tasks ~w(test)
+  @default_task "test"
   @default_clear false
   @default_timestamp false
   @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
   @default_extra_extensions []
-  @default_cli_executable "mix"
   @default_list_all_files &TestFiles.list/0
 
   defstruct clear: @default_clear,
-            cli_executable: @default_cli_executable,
             exclude: @default_exclude,
             extra_extensions: @default_extra_extensions,
             failed?: false,
@@ -26,7 +24,7 @@ defmodule MixTestInteractive.Config do
             patterns: [],
             runner: @default_runner,
             stale?: false,
-            tasks: @default_tasks,
+            task: @default_task,
             timestamp: @default_timestamp
 
   @spec new([String.t()]) :: %__MODULE__{}
@@ -39,14 +37,13 @@ defmodule MixTestInteractive.Config do
 
     %__MODULE__{
       clear: get_clear(),
-      cli_executable: get_cli_executable(),
       exclude: get_excluded(),
       extra_extensions: get_extra_extensions(),
       failed?: failed?,
       initial_cli_args: args,
       runner: get_runner(),
       stale?: stale?,
-      tasks: get_tasks(),
+      task: get_task(),
       timestamp: get_timestamp()
     }
   end
@@ -124,8 +121,8 @@ defmodule MixTestInteractive.Config do
     Application.get_env(@application, :runner, @default_runner)
   end
 
-  defp get_tasks do
-    Application.get_env(@application, :tasks, @default_tasks)
+  defp get_task do
+    Application.get_env(@application, :task, @default_task)
   end
 
   defp get_clear do
@@ -138,10 +135,6 @@ defmodule MixTestInteractive.Config do
 
   defp get_excluded do
     Application.get_env(@application, :exclude, @default_exclude)
-  end
-
-  defp get_cli_executable do
-    Application.get_env(@application, :cli_executable, @default_cli_executable)
   end
 
   defp get_extra_extensions do

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -5,17 +5,17 @@ defmodule MixTestInteractive.ConfigTest do
   alias MixTestInteractive.Config
 
   describe "creation" do
-    test "takes :tasks from the env" do
-      TemporaryEnv.put :mix_test_interactive, :tasks, :env_tasks do
+    test "takes :task from the env" do
+      TemporaryEnv.put :mix_test_interactive, :task, :env_task do
         config = Config.new()
-        assert config.tasks == :env_tasks
+        assert config.task == :env_task
       end
     end
 
-    test ~s(defaults :tasks to ["test"]) do
-      TemporaryEnv.delete :mix_test_interactive, :tasks do
+    test ~s(defaults :task to "test") do
+      TemporaryEnv.delete :mix_test_interactive, :task do
         config = Config.new()
-        assert config.tasks == ["test"]
+        assert config.task == "test"
       end
     end
 
@@ -55,13 +55,6 @@ defmodule MixTestInteractive.ConfigTest do
       TemporaryEnv.put :mix_test_interactive, :timestamp, true do
         config = Config.new()
         assert config.timestamp
-      end
-    end
-
-    test "takes :shell_prefix from the env" do
-      TemporaryEnv.put :mix_test_interactive, :cli_executable, "iex -S" do
-        config = Config.new()
-        assert config.cli_executable == "iex -S"
       end
     end
   end

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -3,7 +3,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
   alias MixTestInteractive.{Config, PortRunner}
 
-  describe "build_tasks_cmds/1" do
+  describe "build_task_command/1" do
     test "appends commandline arguments from passed config" do
       config = Config.new(["--exclude", "integration"])
 
@@ -11,17 +11,17 @@ defmodule MixTestInteractive.PortRunnerTest do
         "MIX_ENV=test mix do run -e " <>
           "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "test --exclude integration"
 
-      assert {:ok, ^expected} = PortRunner.build_tasks_cmds(config)
+      assert {:ok, ^expected} = PortRunner.build_task_command(config)
     end
 
-    test "take the command cli_executable from passed config" do
-      config = %Config{cli_executable: "iex -S mix"}
+    test "takes custom task from passed config" do
+      config = %Config{task: "custom_task"}
 
       expected =
-        "MIX_ENV=test iex -S mix do run -e " <>
-          "'Application.put_env(:elixir, :ansi_enabled, true);', test"
+        "MIX_ENV=test mix do run -e " <>
+          "'Application.put_env(:elixir, :ansi_enabled, true);', " <> "custom_task"
 
-      assert {:ok, ^expected} = PortRunner.build_tasks_cmds(config)
+      assert {:ok, ^expected} = PortRunner.build_task_command(config)
     end
 
     test "respect no-start commandline argument from passed config" do
@@ -32,7 +32,7 @@ defmodule MixTestInteractive.PortRunnerTest do
           "'Application.put_env(:elixir, :ansi_enabled, true);', " <>
           "test --exclude integration --no-start"
 
-      assert {:ok, ^expected} = PortRunner.build_tasks_cmds(config)
+      assert {:ok, ^expected} = PortRunner.build_task_command(config)
     end
   end
 end


### PR DESCRIPTION
Because `mix test.interactive` is geared towards running `mix test` interactively, some of the configuration options inherited from mix-test.watch don't make as much sense.

With interactive mode, changing the CLI executable from `mix` to `iex -S mix` doesn't work, so we now hard-code that to `mix`.  If there is another use case for this option, I'm willing to reconsider.

The support for running multiple tasks was not ideal, as it would pass the same arguments to all of the commands, which is probably not what we really want (see https://github.com/lpil/mix-test.watch/issues/80 for example).

However, there is still a use for defining a task alias that runs `mix test` under the hood, so we still allow configuration of a single task.  However, `mix test.interactive` assumes that the custom task accepts the same command-line arguments as `mix test`.

Again, if there is a legitimate use case for running multiple tasks, I'm willing to consider adding that feature back, but I'd want to find a way to allow different arguments to be passed to different tasks.