### PR TITLE
✨ Initialize patterns from command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ The task is run with `MIX_ENV` set to `test`.
 ## Passing Arguments To Tasks
 
 Any command line arguments passed to the `mix test.interactive` task will be passed
-through to all of the tasks being run, along with any arguments added by interactive mode. If I want to see detailed trace information for my tests, I can run:
+through to the task being run, along with any arguments added by interactive mode. If I want to see detailed trace information for my tests, I can run:
 
 ```
 mix test.interactive --trace
 ```
 
-`mix test.interactive` will detect the `--stale` and `--failed` arguments and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed.
+`mix test.interactive` will detect the `--stale` and `--failed` flags and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed. It will also detect any filename or pattern arguments and use those as initial settings. However, it does not detect any filenames passed with `--include` or `--only`. Note that if you specify a pattern on the command-line, `mix test.interactive` will find all test files matching that pattern and pass those to `mix test` as if you had used the `p` command.
 
 ## Clearing The Console Before Each Run
 


### PR DESCRIPTION
Initializes the matching patterns from the command-line.  Patterns are applied as if they were specified by the `p` command.

Ignores any filenames provided by the `--include` or `--only` flags.

In order for this to work properly, we need to know all of the options and their types supported by `mix test` in order to properly parse the command line.  Otherwise, a user could run `mix test.interactive --trace pattern` and the option parser would treat `--trace` as a string with the value `pattern` rather than as a boolean flag with a separate `pattern`.

The downside to this is that it introduces a compatibility issue if a future version of `mix test` adds a new command-line option. Until we update our list, users will not be able to pass the new option through `mix test.interactive`.

At present, the tradeoff feels worth it, because now users can start `mix test.interactive` with an initial pattern without having to wait for the initial test run.