### PR TITLE
🐛 Use proper command on Windows

### DIFF
--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -10,45 +10,40 @@ defmodule MixTestInteractive.PortRunner do
   @doc """
   Run tests using the runner from the config.
   """
-  def run(%Config{} = config) do
-    with {:ok, command} <- build_task_command(config) do
-      case :os.type() do
+  def run(%Config{} = config, os_type \\ :os.type(), runner \\ &System.cmd/3) do
+    with {:ok, cli_args} <- Config.cli_args(config),
+         command <- [config.task | cli_args] do
+      case os_type do
         {:win32, _} ->
-          System.cmd("cmd", ["/C", "set MIX_ENV=test&& mix test"], into: IO.stream(:stdio, :line))
+          runner.("mix", command,
+            env: [{"MIX_ENV", "test"}],
+            into: IO.stream(:stdio, :line)
+          )
 
         _ ->
+          command = enable_ansi(command)
+
           Path.join(:code.priv_dir(@application), "zombie_killer")
-          |> System.cmd(["sh", "-c", command], into: IO.stream(:stdio, :line))
+          |> runner.(["mix" | command],
+            env: [{"MIX_ENV", "test"}],
+            into: IO.stream(:stdio, :line)
+          )
       end
 
       :ok
     end
   end
 
-  @doc """
-  Build a shell command that runs the desired mix task(s).
+  defp enable_ansi(command) do
+    enable_command = "Application.put_env(:elixir, :ansi_enabled, true);"
 
-  Colour is forced on- normally Elixir would not print ANSI colours while
-  running inside a port.
-  """
-  def build_task_command(%Config{} = config) do
-    with {:ok, cli_args} <- Config.cli_args(config) do
-      args = Enum.join(cli_args, " ")
+    run =
+      if Enum.member?(command, "--no-start") do
+        ["run", "--no-start", "-e"]
+      else
+        ["run", "-e"]
+      end
 
-      ansi =
-        case Enum.member?(cli_args, "--no-start") do
-          true -> "run --no-start -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
-          false -> "run -e 'Application.put_env(:elixir, :ansi_enabled, true);'"
-        end
-
-      command =
-        ["mix", "do", ansi <> ",", config.task, args]
-        |> Enum.filter(& &1)
-        |> Enum.join(" ")
-        |> (fn command -> "MIX_ENV=test #{command}" end).()
-        |> String.trim()
-
-      {:ok, command}
-    end
+    ["do"] ++ run ++ [enable_command, ","] ++ command
   end
 end


### PR DESCRIPTION
As reported in https://github.com/lpil/mix-test.watch/issues/103, the code we adopted from mix-test.watch was always running `mix test` without arguments on Windows even if a custom command or other options were provided.

Now, we run the proper command on Windows.

As reported in https://github.com/lpil/mix-test.watch/pull/104, I also had trouble getting past the quote and backslash issues with the ANSI-enable command on Windows. Plus, in my experimenting, I found that a basic Windows command shell doesn't support ANSI commands.

Therefore, we do not enable ANSI output when running on Windows.

If someone is able to figure out the quoting/backslash issues and help fix the problem, I'm open to solutions.