### PR TITLE
✨ Enable/disable watch mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ mix test.interactive
 
 Your tests will run immediately (and every time a file changes).
 
+If you don't want tests to run automatically when files change, you can start `mix test.interactive` with the `--no-watch` flag:
+
+```shell
+mix test.interactive --no-watch
+```
+
 After the tests run, you can use the interactive mode to change which tests will run.
 
 Use the `p` command to run only test files that match one or more provided patterns. A pattern is the project-root-relative path to a test file (with or without a line number specification) or a string that matches a portion of full pathname. e.g. `test/my_project/my_test.exs`, `test/my_project/my_test.exs:12:24` or `my`.
@@ -41,6 +47,8 @@ Use the `s` command to run only test files that reference modules that have chan
 Use the `f` command to run only tests that failed on the last run (equivalent to the `--failed` option of `mix test`).
 
 Use the `a` command to run all tests.
+
+Use the `w` command to turn file-watching mode on or off.
 
 Use the `Enter` key to re-run the current set of tests without requiring a file change.
 

--- a/lib/mix_test_interactive/command.ex
+++ b/lib/mix_test_interactive/command.ex
@@ -1,7 +1,7 @@
 defmodule MixTestInteractive.Command do
   alias MixTestInteractive.Config
 
-  @type response :: {:ok, Config.t()} | :help | :quit | :unknown
+  @type response :: {:ok, Config.t()} | {:no_run, Config.t()} | :help | :quit | :unknown
 
   @callback applies?(Config.t()) :: boolean()
   @callback description :: String.t()

--- a/lib/mix_test_interactive/command/toggle_watch_mode.ex
+++ b/lib/mix_test_interactive/command/toggle_watch_mode.ex
@@ -1,0 +1,10 @@
+defmodule MixTestInteractive.Command.ToggleWatchMode do
+  alias MixTestInteractive.{Command, Config}
+
+  use Command, command: "w", desc: "turn watch mode on/off"
+
+  @impl Command
+  def run(_args, config) do
+    {:no_run, Config.toggle_watch_mode(config)}
+  end
+end

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -3,7 +3,17 @@ defmodule MixTestInteractive.CommandProcessor do
 
   alias MixTestInteractive.Config
   alias MixTestInteractive.Command
-  alias MixTestInteractive.Command.{AllTests, Failed, Help, Pattern, Quit, RunTests, Stale}
+
+  alias MixTestInteractive.Command.{
+    AllTests,
+    Failed,
+    Help,
+    Pattern,
+    Quit,
+    RunTests,
+    Stale,
+    ToggleWatchMode
+  }
 
   @spec call(String.t() | :eof, Config.t()) :: Command.response()
 
@@ -12,6 +22,7 @@ defmodule MixTestInteractive.CommandProcessor do
     Stale,
     Failed,
     AllTests,
+    ToggleWatchMode,
     RunTests,
     Help,
     Quit

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -7,6 +7,10 @@ defmodule MixTestInteractive.Config do
 
   @application :mix_test_interactive
 
+  @options [
+    watch: :boolean
+  ]
+
   @mix_test_options [
     archives_check: :boolean,
     color: :boolean,
@@ -53,17 +57,19 @@ defmodule MixTestInteractive.Config do
             runner: @default_runner,
             stale?: false,
             task: @default_task,
-            timestamp: @default_timestamp
+            timestamp: @default_timestamp,
+            watching?: true
 
   @spec new([String.t()]) :: %__MODULE__{}
   @doc """
   Create a new config struct, taking values from the ENV
   """
   def new(cli_args \\ []) do
-    {opts, patterns} = OptionParser.parse!(cli_args, switches: @mix_test_options)
+    {opts, patterns} = OptionParser.parse!(cli_args, switches: @options ++ @mix_test_options)
     no_patterns? = Enum.empty?(patterns)
     {failed?, opts} = Keyword.pop(opts, :failed, false)
     {stale?, opts} = Keyword.pop(opts, :stale, false)
+    {watching?, opts} = Keyword.pop(opts, :watch, true)
 
     %__MODULE__{
       clear: get_clear(),
@@ -75,7 +81,8 @@ defmodule MixTestInteractive.Config do
       runner: get_runner(),
       stale?: no_patterns? && !failed? && stale?,
       task: get_task(),
-      timestamp: get_timestamp()
+      timestamp: get_timestamp(),
+      watching?: watching?
     }
   end
 
@@ -83,6 +90,10 @@ defmodule MixTestInteractive.Config do
     with {:ok, args} <- args_from_settings(config) do
       {:ok, initial_args ++ args}
     end
+  end
+
+  def toggle_watch_mode(config) do
+    %{config | watching?: !config.watching?}
   end
 
   def only_patterns(config, patterns) do

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -10,7 +10,7 @@ defmodule MixTestInteractive.InteractiveMode do
   def run(config) do
     :ok = run_tests(config)
     show_summary(config)
-    show_usage_prompt()
+    show_usage_prompt(config)
   end
 
   defp loop(config) do
@@ -20,6 +20,11 @@ defmodule MixTestInteractive.InteractiveMode do
       {:ok, new_config} ->
         ConfigStore.store(new_config)
         run(new_config)
+        loop(new_config)
+
+      {:no_run, new_config} ->
+        ConfigStore.store(new_config)
+        show_usage_prompt(new_config)
         loop(new_config)
 
       :help ->
@@ -58,7 +63,15 @@ defmodule MixTestInteractive.InteractiveMode do
     |> IO.puts()
   end
 
-  defp show_usage_prompt() do
+  defp show_usage_prompt(config) do
+    IO.puts("")
+
+    if config.watching? do
+      IO.puts("Watching for file changes...")
+    else
+      IO.puts("Ignoring file changes")
+    end
+
     IO.puts("")
 
     [:bright, "Usage: ?", :normal, " to show more"]

--- a/lib/mix_test_interactive/watcher.ex
+++ b/lib/mix_test_interactive/watcher.ex
@@ -36,7 +36,7 @@ defmodule MixTestInteractive.Watcher do
     config = ConfigStore.config()
     path = to_string(path)
 
-    if Paths.watching?(path, config) do
+    if config.watching? && Paths.watching?(path, config) do
       InteractiveMode.run(config)
       MessageInbox.flush()
     end

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -57,6 +57,13 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^expected} = process_command("a", config)
     end
 
+    test "w toggles watch mode" do
+      config = Config.new()
+      expected = Config.toggle_watch_mode(config)
+
+      assert {:no_run, ^expected} = process_command("w", config)
+    end
+
     test "? returns :help" do
       config = Config.new()
 

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -59,6 +59,46 @@ defmodule MixTestInteractive.ConfigTest do
     end
   end
 
+  describe "watch mode" do
+    test "enabled by default" do
+      config = Config.new()
+
+      assert config.watching?
+    end
+
+    test "disables with --no-watch flag" do
+      config = Config.new(["--no-watch"])
+      refute config.watching?
+    end
+
+    test "consumes --watch flag" do
+      config = Config.new(["--watch"])
+      assert {:ok, []} = Config.cli_args(config)
+    end
+
+    test "consumes --no-watch flag" do
+      config = Config.new(["--no-watch"])
+      assert {:ok, []} = Config.cli_args(config)
+    end
+
+    test "toggles off" do
+      config =
+        Config.new()
+        |> Config.toggle_watch_mode()
+
+      refute config.watching?
+    end
+
+    test "toggles back on" do
+      config =
+        Config.new()
+        |> Config.toggle_watch_mode()
+        |> Config.toggle_watch_mode()
+
+      assert config.watching?
+    end
+  end
+
   describe "command line arguments" do
     test "passes on provided arguments" do
       config = Config.new(["--trace", "--raise"])


### PR DESCRIPTION
Allows file-watching mode to be turned on or off (on by default).

Turn off at startup with `mix test.interactive --no-watch`.

Once running, toggle watch mode on/off with the `w` command.