### PR TITLE
♻️ Pass CLI args to runner

### DIFF
--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -104,7 +104,8 @@ defmodule MixTestInteractive.InteractiveMode do
   end
 
   defp do_run_tests(config, settings) do
-    with :ok <- Runner.run(config, settings) do
+    with {:ok, args} <- Settings.cli_args(settings),
+         :ok <- Runner.run(config, args) do
       :ok
     else
       {:error, :no_matching_files} ->

--- a/lib/mix_test_interactive/runner.ex
+++ b/lib/mix_test_interactive/runner.ex
@@ -5,17 +5,17 @@ defmodule MixTestInteractive.Runner do
   Also responsible for optionally clearing the terminal and printing the current time.
   """
 
-  alias MixTestInteractive.{Config, Settings}
+  alias MixTestInteractive.Config
 
   @doc """
   Run tests using configured runner.
   """
-  @spec run(Config.t(), Settings.t()) :: :ok | {:error, term()}
-  def run(config, settings) do
+  @spec run(Config.t(), [String.t()]) :: :ok
+  def run(config, args) do
     :ok = maybe_clear_terminal(config)
     IO.puts("\nRunning tests...")
     :ok = maybe_print_timestamp(config)
-    config.runner.run(config, settings)
+    config.runner.run(config, args)
   end
 
   defp maybe_clear_terminal(%{clear?: false}), do: :ok

--- a/test/mix_test_interactive/runner_test.exs
+++ b/test/mix_test_interactive/runner_test.exs
@@ -3,11 +3,11 @@ defmodule MixTestInteractive.RunnerTest do
 
   import ExUnit.CaptureIO
 
-  alias MixTestInteractive.{Config, Runner, Settings}
+  alias MixTestInteractive.{Config, Runner}
 
   defmodule DummyRunner do
-    def run(config, settings) do
-      Agent.get_and_update(__MODULE__, fn data -> {:ok, [{config, settings} | data]} end)
+    def run(config, args) do
+      Agent.get_and_update(__MODULE__, fn data -> {:ok, [{config, args} | data]} end)
     end
   end
 
@@ -19,14 +19,14 @@ defmodule MixTestInteractive.RunnerTest do
   describe "run/1" do
     test "It delegates to the runner specified by the config" do
       config = %Config{runner: DummyRunner}
-      settings = Settings.new()
+      args = ["--cover", "--raise"]
 
       output =
         capture_io(fn ->
-          Runner.run(config, settings)
+          Runner.run(config, args)
         end)
 
-      assert Agent.get(DummyRunner, fn x -> x end) == [{config, settings}]
+      assert Agent.get(DummyRunner, fn x -> x end) == [{config, args}]
 
       assert output == """
 
@@ -36,14 +36,13 @@ defmodule MixTestInteractive.RunnerTest do
 
     test "It outputs timestamp when specified by the config" do
       config = %Config{runner: DummyRunner, show_timestamp?: true}
-      settings = Settings.new()
 
       output =
         capture_io(fn ->
-          Runner.run(config, settings)
+          Runner.run(config, [])
         end)
 
-      assert Agent.get(DummyRunner, fn x -> x end) == [{config, settings}]
+      assert Agent.get(DummyRunner, fn x -> x end) == [{config, []}]
 
       timestamp =
         output


### PR DESCRIPTION
Instead of passing the Settings to the runner, only pass the CLI args.

This will make it easier to have (almost) end-to-end tests, and also isolates the handling of the `no matching tests` error higher in the call stack.