### PR TITLE
feat: Support before_task and after_task

### DIFF
--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -7,6 +7,8 @@ defmodule MixTestInteractive.Config do
 
   @default_runner MixTestInteractive.PortRunner
   @default_task "test"
+  @default_before_task []
+  @default_after_task []
   @default_clear false
   @default_show_timestamp false
   @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
@@ -19,6 +21,8 @@ defmodule MixTestInteractive.Config do
     field(:runner, module(), default: @default_runner)
     field(:show_timestamp?, boolean(), default: @default_show_timestamp)
     field(:task, String.t(), default: @default_task)
+    field(:before_task, [[String.t()]], default: @default_before_task)
+    field(:after_task, [[String.t()]], default: @default_after_task)
   end
 
   @application :mix_test_interactive
@@ -34,7 +38,9 @@ defmodule MixTestInteractive.Config do
       extra_extensions: get_extra_extensions(),
       runner: get_runner(),
       show_timestamp?: get_show_timestamp(),
-      task: get_task()
+      task: get_task(),
+      before_task: get_before_task(),
+      after_task: get_after_task()
     }
   end
 
@@ -44,6 +50,14 @@ defmodule MixTestInteractive.Config do
 
   defp get_task do
     Application.get_env(@application, :task, @default_task)
+  end
+
+  defp get_before_task do
+    Application.get_env(@application, :before_task, @default_before_task)
+  end
+
+  defp get_after_task do
+    Application.get_env(@application, :after_task, @default_after_task)
   end
 
   defp get_clear do

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -26,7 +26,7 @@ defmodule MixTestInteractive.PortRunnerTest do
     end
 
     test "runs mix test directly in test environment by default" do
-      assert {"mix", ["test"], options} = run_windows()
+      assert {"mix", ["do", "test"], options} = run_windows()
 
       assert Keyword.get(options, :env) == [{"MIX_ENV", "test"}]
     end
@@ -39,7 +39,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
     test "uses custom task" do
       config = %Config{task: "custom"}
-      assert {_command, ["custom"], _options} = run_windows(config: config)
+      assert {_command, ["do", "custom"], _options} = run_windows(config: config)
     end
   end
 


### PR DESCRIPTION
This adds support for `before_task` and `after_task` config options.

It allows you to run tasks before and after the actual test task.

Usage would be like:

```elixir
config :mix_test_interactive, :before_task, [
  ["run", "-e", ~s|IO.puts("RAN BEFORE")|],
  ["my_task_before"]
]

config :mix_test_interactive, :after_task, [
  ["my_task_after", "some_arg"],
]
```

I would like to know if you have any feedback before adding tests and updating the docs.