### PR TITLE
Add command to filter by test `@tag :tag` attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ If any pattern contains a line number specification, all patterns are passed dir
 p pattern1 pattern 2
 ```
 
+Use the `t` command to run only tests tagged with matching tags, via `@tag :tag`.
+
+```
+t focus slowest
+```
+
 Use the `s` command to run only test files that reference modules that have changed since the last run (equivalent to the `--stale` option of `mix test`).
 
 Use the `f` command to run only tests that failed on the last run (equivalent to the `--failed` option of `mix test`).

--- a/lib/mix_test_interactive/command/tags.ex
+++ b/lib/mix_test_interactive/command/tags.ex
@@ -1,0 +1,21 @@
+defmodule MixTestInteractive.Command.Tags do
+  @moduledoc """
+  Specify one or more tags.
+
+  Runs all tests that are tagged with at least one of the given tags.
+
+  Equivalent to `mix test --only <tag>`.
+  """
+
+  alias MixTestInteractive.{Command, Settings}
+
+  use Command, command: "t", desc: "run only tests matching tag(s)"
+
+  @impl Command
+  def name, do: "t <tags>"
+
+  @impl Command
+  def run(tags, settings) do
+    {:ok, Settings.only_tags(settings, tags)}
+  end
+end

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -13,6 +13,7 @@ defmodule MixTestInteractive.CommandProcessor do
     Quit,
     RunTests,
     Stale,
+    Tags,
     ToggleWatchMode
   }
 
@@ -20,6 +21,7 @@ defmodule MixTestInteractive.CommandProcessor do
 
   @commands [
     Pattern,
+    Tags,
     Stale,
     Failed,
     AllTests,

--- a/lib/mix_test_interactive/settings.ex
+++ b/lib/mix_test_interactive/settings.ex
@@ -18,6 +18,7 @@ defmodule MixTestInteractive.Settings do
     field(:list_all_files, (() -> [String.t()]), default: @default_list_all_files)
     field(:patterns, [String.t()], default: [])
     field(:stale?, boolean(), default: false)
+    field(:tags, [String.t()], default: [])
     field(:watching?, boolean(), default: true)
   end
 
@@ -110,6 +111,18 @@ defmodule MixTestInteractive.Settings do
   end
 
   @doc """
+  Provide a list of tag patterns.
+
+  Only tests matching one or more of the tags will be run.
+  """
+  @spec only_tags(t(), [String.t()]) :: t()
+  def only_tags(settings, tags) do
+    settings
+    |> all_tests()
+    |> Map.put(:tags, tags)
+  end
+
+  @doc """
   Update settings to only run failing tests.
 
   Corresponds to `mix test --failed`.
@@ -179,6 +192,11 @@ defmodule MixTestInteractive.Settings do
       [] -> {:error, :no_matching_files}
       files -> {:ok, files}
     end
+  end
+
+  defp args_from_settings(%__MODULE__{tags: [_ | _] = tags}) do
+    tag_args = Enum.map(tags, &["--only", &1]) |> List.flatten()
+    {:ok, tag_args}
   end
 
   defp args_from_settings(_config), do: {:ok, []}

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -36,6 +36,13 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^expected} = process_command("p second", first_config)
     end
 
+    test "t filters by tags matching the provided pattern" do
+      settings = Settings.new()
+      expected = Settings.only_tags(settings, ["focus"])
+
+      assert {:ok, ^expected} = process_command("t focus", settings)
+    end
+
     test "s runs only stale tests" do
       settings = Settings.new()
       expected = Settings.only_stale(settings)


### PR DESCRIPTION
Adds the `t` command to the interactive runner.

## Usage

`t tag1 tag2`

will append `--only tag1 --only tag2` to the end of the test command being run, ensuring that only tests with `@tag :tag1` or `@tag :tag2` are run.

Like the `p` command, the list of tags can be cleared by passing `t` alone to the interactive runner.