### PR TITLE
💥 Update supported Elixir versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: circleci/elixir:<< parameters.elixir >>
+      - image: cimg/elixir:<< parameters.elixir >>
         environment:
           MIX_ENV: test
     parameters:
@@ -33,4 +33,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              elixir: ["1.8", "1.9", "1.10", "1.11", "1.12", "1.13"]
+              elixir: ["1.11", "1.12", "1.13", "1.14", "1.15"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,11 @@ jobs:
             - _build
             - deps
             - ~/.mix
-      - run: mix format --check-formatted
+      - when:
+          condition:
+            equal: ["1.15", << parameters.elixir >>]
+          steps:
+            - run: mix format --check-formatted
       - run: mix test
 
 workflows:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.2
-elixir 1.13.3-otp-24
+erlang 26.0.2
+elixir 1.15.5-otp-26

--- a/lib/mix_test_interactive/settings.ex
+++ b/lib/mix_test_interactive/settings.ex
@@ -15,7 +15,7 @@ defmodule MixTestInteractive.Settings do
   typedstruct do
     field(:failed?, boolean(), default: false)
     field(:initial_cli_args, [String.t()], default: [])
-    field(:list_all_files, (() -> [String.t()]), default: @default_list_all_files)
+    field(:list_all_files, (-> [String.t()]), default: @default_list_all_files)
     field(:patterns, [String.t()], default: [])
     field(:stale?, boolean(), default: false)
     field(:watching?, boolean(), default: true)

--- a/lib/mix_test_interactive/watcher.ex
+++ b/lib/mix_test_interactive/watcher.ex
@@ -27,7 +27,7 @@ defmodule MixTestInteractive.Watcher do
         {:ok, config}
 
       other ->
-        Logger.warn("""
+        Logger.warning("""
         Could not start the file system monitor.
         """)
 


### PR DESCRIPTION
**BREAKING:** Dropped support for all Elixir versions prior to 1.11 which matches the [list of supported releases](https://hexdocs.pm/elixir/1.15.5/compatibility-and-deprecations.html).

Use latest Elixir/Erlang versions locally.

Update list of versions in CI to include all supported versions.