### PR TITLE
🎨 Adopt Styler for formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  plugins: [Styler]
 ]

--- a/lib/mix/tasks/test/interactive.ex
+++ b/lib/mix/tasks/test/interactive.ex
@@ -1,11 +1,11 @@
 defmodule Mix.Tasks.Test.Interactive do
-  use Mix.Task
-
+  @shortdoc "Interactively run tests"
   @moduledoc """
   A task for interactively running tests
   """
 
-  @shortdoc "Interactively run tests"
+  use Mix.Task
+
   @preferred_cli_env :test
 
   defdelegate run(args), to: MixTestInteractive

--- a/lib/mix_test_interactive/application.ex
+++ b/lib/mix_test_interactive/application.ex
@@ -3,7 +3,9 @@ defmodule MixTestInteractive.Application do
 
   use Application
 
-  alias MixTestInteractive.{Config, InteractiveMode, Watcher}
+  alias MixTestInteractive.Config
+  alias MixTestInteractive.InteractiveMode
+  alias MixTestInteractive.Watcher
 
   @impl Application
   def start(_type, _args) do

--- a/lib/mix_test_interactive/command/all_tests.ex
+++ b/lib/mix_test_interactive/command/all_tests.ex
@@ -3,9 +3,10 @@ defmodule MixTestInteractive.Command.AllTests do
   Run all tests, removing any flags or filters.
   """
 
-  alias MixTestInteractive.{Command, Settings}
+  use MixTestInteractive.Command, command: "a", desc: "run all tests"
 
-  use Command, command: "a", desc: "run all tests"
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Settings
 
   @impl Command
   def applies?(%Settings{failed?: true}), do: true

--- a/lib/mix_test_interactive/command/failed.ex
+++ b/lib/mix_test_interactive/command/failed.ex
@@ -5,9 +5,10 @@ defmodule MixTestInteractive.Command.Failed do
   Equivalent to `mix test --failed`.
   """
 
-  alias MixTestInteractive.{Command, Settings}
+  use MixTestInteractive.Command, command: "f", desc: "run only failed tests"
 
-  use Command, command: "f", desc: "run only failed tests"
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Settings
 
   @impl Command
   def applies?(%Settings{failed?: false}), do: true

--- a/lib/mix_test_interactive/command/help.ex
+++ b/lib/mix_test_interactive/command/help.ex
@@ -5,9 +5,9 @@ defmodule MixTestInteractive.Command.Help do
   Lists all commands applicable to the current context.
   """
 
-  alias MixTestInteractive.Command
+  use MixTestInteractive.Command, command: "?", desc: "show help"
 
-  use Command, command: "?", desc: "show help"
+  alias MixTestInteractive.Command
 
   @impl Command
   def run(_args, _settings), do: :help

--- a/lib/mix_test_interactive/command/pattern.ex
+++ b/lib/mix_test_interactive/command/pattern.ex
@@ -9,9 +9,10 @@ defmodule MixTestInteractive.Command.Pattern do
   only supports a single filename-with-line-number pattern at a time.
   """
 
-  alias MixTestInteractive.{Command, Settings}
+  use MixTestInteractive.Command, command: "p", desc: "run only test files matching pattern(s)"
 
-  use Command, command: "p", desc: "run only test files matching pattern(s)"
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Settings
 
   @impl Command
   def name, do: "p <patterns>"

--- a/lib/mix_test_interactive/command/quit.ex
+++ b/lib/mix_test_interactive/command/quit.ex
@@ -3,9 +3,9 @@ defmodule MixTestInteractive.Command.Quit do
   Exit mix test.interactive.
   """
 
-  alias MixTestInteractive.Command
+  use MixTestInteractive.Command, command: "q", desc: "quit"
 
-  use Command, command: "q", desc: "quit"
+  alias MixTestInteractive.Command
 
   @impl Command
   def run(_args, _settings), do: :quit

--- a/lib/mix_test_interactive/command/run_tests.ex
+++ b/lib/mix_test_interactive/command/run_tests.ex
@@ -3,9 +3,9 @@ defmodule MixTestInteractive.Command.RunTests do
   Run all tests matching the current flags and filter settings.
   """
 
-  alias MixTestInteractive.Command
+  use MixTestInteractive.Command, command: "", desc: "trigger a test run"
 
-  use Command, command: "", desc: "trigger a test run"
+  alias MixTestInteractive.Command
 
   @impl Command
   def name, do: "Enter"

--- a/lib/mix_test_interactive/command/stale.ex
+++ b/lib/mix_test_interactive/command/stale.ex
@@ -5,9 +5,10 @@ defmodule MixTestInteractive.Command.Stale do
   Equivalent to `mix test --stale`.
   """
 
-  alias MixTestInteractive.{Command, Settings}
+  use MixTestInteractive.Command, command: "s", desc: "run only stale tests"
 
-  use Command, command: "s", desc: "run only stale tests"
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Settings
 
   @impl Command
   def applies?(%Settings{stale?: false}), do: true

--- a/lib/mix_test_interactive/command/toggle_watch_mode.ex
+++ b/lib/mix_test_interactive/command/toggle_watch_mode.ex
@@ -10,9 +10,10 @@ defmodule MixTestInteractive.Command.ToggleWatchMode do
   `MixTestInteractive.Command.RunTests` command.
   """
 
-  alias MixTestInteractive.{Command, Settings}
+  use MixTestInteractive.Command, command: "w", desc: "turn watch mode on/off"
 
-  use Command, command: "w", desc: "turn watch mode on/off"
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Settings
 
   @impl Command
   def run(_args, settings) do

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -3,18 +3,16 @@ defmodule MixTestInteractive.CommandProcessor do
   Processes interactive mode commands.
   """
 
-  alias MixTestInteractive.{Command, Settings}
-
-  alias MixTestInteractive.Command.{
-    AllTests,
-    Failed,
-    Help,
-    Pattern,
-    Quit,
-    RunTests,
-    Stale,
-    ToggleWatchMode
-  }
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Command.AllTests
+  alias MixTestInteractive.Command.Failed
+  alias MixTestInteractive.Command.Help
+  alias MixTestInteractive.Command.Pattern
+  alias MixTestInteractive.Command.Quit
+  alias MixTestInteractive.Command.RunTests
+  alias MixTestInteractive.Command.Stale
+  alias MixTestInteractive.Command.ToggleWatchMode
+  alias MixTestInteractive.Settings
 
   @type response :: Command.response()
 
@@ -54,13 +52,11 @@ defmodule MixTestInteractive.CommandProcessor do
       |> applicable_commands()
       |> Enum.flat_map(&usage_line/1)
 
-    ([:bright, "Usage:\n", :normal] ++ usage)
-    |> IO.ANSI.format()
+    IO.ANSI.format([:bright, "Usage:\n", :normal] ++ usage)
   end
 
   defp usage_line(command) do
-    ["› ", :bright, command.name, :normal, " to ", command.description, ".\n"]
-    |> IO.ANSI.format_fragment()
+    IO.ANSI.format_fragment(["› ", :bright, command.name, :normal, " to ", command.description, ".\n"])
   end
 
   defp process_command(command, args, settings) do

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -27,7 +27,7 @@ defmodule MixTestInteractive.Config do
   Create a new config struct, taking values from the application environment.
   """
   @spec new() :: t()
-  def new() do
+  def new do
     %__MODULE__{
       clear?: get_clear(),
       exclude: get_excluded(),

--- a/lib/mix_test_interactive/interactive_mode.ex
+++ b/lib/mix_test_interactive/interactive_mode.ex
@@ -11,7 +11,10 @@ defmodule MixTestInteractive.InteractiveMode do
 
   use GenServer, restart: :transient
 
-  alias MixTestInteractive.{CommandProcessor, Config, Runner, Settings}
+  alias MixTestInteractive.CommandProcessor
+  alias MixTestInteractive.Config
+  alias MixTestInteractive.Runner
+  alias MixTestInteractive.Settings
 
   @type option :: {:config, Config.t()} | {:name | String.t()}
 

--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -10,24 +10,19 @@ defmodule MixTestInteractive.PortRunner do
   supported by Windows command processors.
   """
 
+  alias MixTestInteractive.Config
+
   @application :mix_test_interactive
   @type runner ::
           (String.t(), [String.t()], keyword() ->
              {Collectable.t(), exit_status :: non_neg_integer()})
   @type os_type :: {atom(), atom()}
 
-  alias MixTestInteractive.Config
-
   @doc """
   Run tests based on the current configuration.
   """
   @spec run(Config.t(), [String.t()], os_type(), runner()) :: :ok
-  def run(
-        %Config{} = config,
-        args,
-        os_type \\ :os.type(),
-        runner \\ &System.cmd/3
-      ) do
+  def run(%Config{} = config, args, os_type \\ :os.type(), runner \\ &System.cmd/3) do
     command = [config.task | args]
 
     case os_type do
@@ -40,7 +35,9 @@ defmodule MixTestInteractive.PortRunner do
       _ ->
         command = enable_ansi(command)
 
-        Path.join(:code.priv_dir(@application), "zombie_killer")
+        @application
+        |> :code.priv_dir()
+        |> Path.join("zombie_killer")
         |> runner.(["mix" | command],
           env: [{"MIX_ENV", "test"}],
           into: IO.stream(:stdio, :line)

--- a/lib/mix_test_interactive/settings.ex
+++ b/lib/mix_test_interactive/settings.ex
@@ -8,7 +8,8 @@ defmodule MixTestInteractive.Settings do
 
   use TypedStruct
 
-  alias MixTestInteractive.{PatternFilter, TestFiles}
+  alias MixTestInteractive.PatternFilter
+  alias MixTestInteractive.TestFiles
 
   @default_list_all_files &TestFiles.list/0
 
@@ -175,7 +176,7 @@ defmodule MixTestInteractive.Settings do
   end
 
   defp args_from_settings(%__MODULE__{patterns: patterns} = settings) when length(patterns) > 0 do
-    case settings.list_all_files.() |> PatternFilter.matches(patterns) do
+    case PatternFilter.matches(settings.list_all_files.(), patterns) do
       [] -> {:error, :no_matching_files}
       files -> {:ok, files}
     end

--- a/lib/mix_test_interactive/test_files.ex
+++ b/lib/mix_test_interactive/test_files.ex
@@ -10,7 +10,7 @@ defmodule MixTestInteractive.TestFiles do
   up immediately.
   """
   @spec list() :: [String.t()]
-  def list() do
+  def list do
     config = Mix.Project.config()
     paths = config[:test_paths] || default_test_paths()
     pattern = config[:test_pattern] || "*_test.exs"

--- a/lib/mix_test_interactive/watcher.ex
+++ b/lib/mix_test_interactive/watcher.ex
@@ -5,7 +5,9 @@ defmodule MixTestInteractive.Watcher do
 
   use GenServer
 
-  alias MixTestInteractive.{InteractiveMode, MessageInbox, Paths}
+  alias MixTestInteractive.InteractiveMode
+  alias MixTestInteractive.MessageInbox
+  alias MixTestInteractive.Paths
 
   require Logger
 

--- a/mix.exs
+++ b/mix.exs
@@ -34,6 +34,7 @@ defmodule MixTestInteractive.MixProject do
     [
       {:ex_doc, "~> 0.28.3", only: :dev, runtime: false},
       {:file_system, "~> 0.2"},
+      {:styler, "~> 0.9.1"},
       {:temporary_env, "~> 2.0", only: :test},
       {:typed_struct, "~> 0.3.0"}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
+  "styler": {:hex, :styler, "0.9.1", "a37e35ac7c4c5b483636fa324f7167a71bdd027d048f91e019b9f32f6dc1a501", [:mix], [], "hexpm", "28e3bb66e727759939bdd0b801dc18d21202cca23ba300bd097b368550aacb40"},
   "temporary_env": {:hex, :temporary_env, "2.0.1", "d4b5e031837e5619485e1f23af7cba7e897b8fd546eaaa8b10c812d642ec4546", [:mix], [], "hexpm", "f9420044742b5f0479a7f8243e86b048b6a2d4878bce026a3615065b11199c27"},
   "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
 }

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -1,7 +1,8 @@
 defmodule MixTestInteractive.CommandProcessorTest do
   use ExUnit.Case, async: true
 
-  alias MixTestInteractive.{CommandProcessor, Settings}
+  alias MixTestInteractive.CommandProcessor
+  alias MixTestInteractive.Settings
 
   defp process_command(command, settings \\ Settings.new([])) do
     CommandProcessor.call(command, settings)
@@ -84,24 +85,21 @@ defmodule MixTestInteractive.CommandProcessorTest do
 
     test "shows relevant commands when filtering by pattern" do
       settings =
-        Settings.new()
-        |> Settings.only_patterns(["pattern"])
+        Settings.only_patterns(Settings.new(), ["pattern"])
 
       assert_commands(settings, ["p <patterns>", "s", "f", "a"], ~w(p))
     end
 
     test "shows relevant commands when running failed tests" do
       settings =
-        Settings.new()
-        |> Settings.only_failed()
+        Settings.only_failed(Settings.new())
 
       assert_commands(settings, ["p <patterns>", "s", "a"], ~w(f))
     end
 
     test "shows relevant commands when running stale tests" do
       settings =
-        Settings.new()
-        |> Settings.only_stale()
+        Settings.only_stale(Settings.new())
 
       assert_commands(settings, ["p <patterns>", "f", "a"], ~w(s))
     end

--- a/test/mix_test_interactive/end_to_end_test.exs
+++ b/test/mix_test_interactive/end_to_end_test.exs
@@ -1,9 +1,11 @@
 defmodule MixTestInteractive.EndToEndTest do
   use ExUnit.Case, async: true
 
-  alias MixTestInteractive.{Config, InteractiveMode}
+  alias MixTestInteractive.Config
+  alias MixTestInteractive.InteractiveMode
 
   defmodule DummyRunner do
+    @moduledoc false
     def run(config, args) do
       Agent.update(__MODULE__, fn test_pid ->
         send(test_pid, {config, args})

--- a/test/mix_test_interactive/message_inbox_test.exs
+++ b/test/mix_test_interactive/message_inbox_test.exs
@@ -1,5 +1,6 @@
 defmodule MixTestInteractive.MessageInboxTest do
   use ExUnit.Case
+
   alias MixTestInteractive.MessageInbox
 
   test "flush clears the process inbox of messages" do

--- a/test/mix_test_interactive/paths_test.exs
+++ b/test/mix_test_interactive/paths_test.exs
@@ -2,6 +2,7 @@ defmodule MixTestInteractive.PathTest do
   use ExUnit.Case
 
   import MixTestInteractive.Paths, only: [watching?: 1, watching?: 2]
+
   alias MixTestInteractive.Config
 
   test ".ex files are watched" do

--- a/test/mix_test_interactive/pattern_filter_test.exs
+++ b/test/mix_test_interactive/pattern_filter_test.exs
@@ -5,9 +5,9 @@ defmodule MixTestInteractive.PatternFilterTest do
 
   @abc "test/project/abc_test.exs"
   @bcd "test/project/bcd_test.exs"
-  @def "test/project/def_test.exs"
+  @cde "test/project/cde_test.exs"
 
-  @files [@abc, @bcd, @def]
+  @files [@abc, @bcd, @cde]
 
   test "returns files matching a pattern" do
     matches = PatternFilter.matches(@files, "bc")
@@ -22,9 +22,9 @@ defmodule MixTestInteractive.PatternFilterTest do
   end
 
   test "returns files matching at least one of multiple patterns" do
-    matches = PatternFilter.matches(@files, ["a", "f"])
+    matches = PatternFilter.matches(@files, ["ab", "de"])
 
-    assert matches == [@abc, @def]
+    assert matches == [@abc, @cde]
   end
 
   test "returns only patterns if any is a file with line number" do

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -1,7 +1,8 @@
 defmodule MixTestInteractive.PortRunnerTest do
   use ExUnit.Case, async: true
 
-  alias MixTestInteractive.{Config, PortRunner}
+  alias MixTestInteractive.Config
+  alias MixTestInteractive.PortRunner
 
   defp run(os_type, options) do
     config = Keyword.get(options, :config, Config.new())

--- a/test/mix_test_interactive/runner_test.exs
+++ b/test/mix_test_interactive/runner_test.exs
@@ -3,9 +3,11 @@ defmodule MixTestInteractive.RunnerTest do
 
   import ExUnit.CaptureIO
 
-  alias MixTestInteractive.{Config, Runner}
+  alias MixTestInteractive.Config
+  alias MixTestInteractive.Runner
 
   defmodule DummyRunner do
+    @moduledoc false
     def run(config, args) do
       Agent.get_and_update(__MODULE__, fn data -> {:ok, [{config, args} | data]} end)
     end

--- a/test/mix_test_interactive/settings_test.exs
+++ b/test/mix_test_interactive/settings_test.exs
@@ -28,8 +28,7 @@ defmodule MixTestInteractive.SettingsTest do
 
     test "toggles off" do
       settings =
-        Settings.new()
-        |> Settings.toggle_watch_mode()
+        Settings.toggle_watch_mode(Settings.new())
 
       refute settings.watching?
     end
@@ -101,7 +100,8 @@ defmodule MixTestInteractive.SettingsTest do
       all_files = ~w(file1 file2 no_match other)
 
       settings =
-        Settings.new(["--trace"])
+        ["--trace"]
+        |> Settings.new()
         |> with_fake_file_list(all_files)
         |> Settings.only_patterns(["file", "other"])
 
@@ -120,7 +120,8 @@ defmodule MixTestInteractive.SettingsTest do
 
     test "restricts to failed tests" do
       settings =
-        Settings.new(["--trace"])
+        ["--trace"]
+        |> Settings.new()
         |> Settings.only_failed()
 
       {:ok, args} = Settings.cli_args(settings)
@@ -129,7 +130,8 @@ defmodule MixTestInteractive.SettingsTest do
 
     test "restricts to stale tests" do
       settings =
-        Settings.new(["--trace"])
+        ["--trace"]
+        |> Settings.new()
         |> Settings.only_stale()
 
       {:ok, args} = Settings.cli_args(settings)
@@ -229,7 +231,7 @@ defmodule MixTestInteractive.SettingsTest do
     end
 
     defp with_fake_file_list(settings, files) do
-      settings |> Settings.list_files_with(fn -> files end)
+      Settings.list_files_with(settings, fn -> files end)
     end
   end
 
@@ -241,19 +243,19 @@ defmodule MixTestInteractive.SettingsTest do
     end
 
     test "ran failed tests" do
-      settings = Settings.new() |> Settings.only_failed()
+      settings = Settings.only_failed(Settings.new())
 
       assert Settings.summary(settings) == "Ran only failed tests"
     end
 
     test "ran stale tests" do
-      settings = Settings.new() |> Settings.only_stale()
+      settings = Settings.only_stale(Settings.new())
 
       assert Settings.summary(settings) == "Ran only stale tests"
     end
 
     test "ran specific patterns" do
-      settings = Settings.new() |> Settings.only_patterns(["p1", "p2"])
+      settings = Settings.only_patterns(Settings.new(), ["p1", "p2"])
 
       assert Settings.summary(settings) == "Ran all test files matching p1, p2"
     end


### PR DESCRIPTION
Adds [Styler](https://github.com/adobe/elixir-styler) to auto-format the codebase.

- Run `mix format` using Styler
- Fix code that broke
- Rename `@def` in `PatternFilterTest` to avoid a bug in Styler