### PR TITLE
📝 Add documentation to the task

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Use the `p` command to run only test files that match one or more provided patte
 If any pattern contains a line number specification, all patterns are passed directly to `mix test`.
 
 ```
-p pattern1 pattern 2
+p pattern1 pattern2
 ```
 
 Use the `s` command to run only test files that reference modules that have changed since the last run (equivalent to the `--stale` option of `mix test`).
@@ -60,6 +60,17 @@ Use the `w` command to turn file-watching mode on or off.
 Use the `Enter` key to re-run the current set of tests without requiring a file change.
 
 Use the `q` command, or press `Ctrl-D` to exit the program.
+
+## Passing Arguments To Tasks
+
+Any command line arguments passed to the `mix test.interactive` task will be passed
+through to the task being run, along with any arguments added by interactive mode. If I want to see detailed trace information for my tests, I can run:
+
+```
+mix test.interactive --trace
+```
+
+`mix test.interactive` will detect the `--stale` and `--failed` flags and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed. It will also detect any filename or pattern arguments and use those as initial settings. However, it does not detect any filenames passed with `--include` or `--only`. Note that if you specify a pattern on the command-line, `mix test.interactive` will find all test files matching that pattern and pass those to `mix test` as if you had used the `p` command.
 
 ## Running A Different Mix Task
 
@@ -76,17 +87,6 @@ end
 ```
 
 The task is run with `MIX_ENV` set to `test`.
-
-## Passing Arguments To Tasks
-
-Any command line arguments passed to the `mix test.interactive` task will be passed
-through to the task being run, along with any arguments added by interactive mode. If I want to see detailed trace information for my tests, I can run:
-
-```
-mix test.interactive --trace
-```
-
-`mix test.interactive` will detect the `--stale` and `--failed` flags and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed. It will also detect any filename or pattern arguments and use those as initial settings. However, it does not detect any filenames passed with `--include` or `--only`. Note that if you specify a pattern on the command-line, `mix test.interactive` will find all test files matching that pattern and pass those to `mix test` as if you had used the `p` command.
 
 ## Clearing The Console Before Each Run
 
@@ -138,7 +138,7 @@ The idea for having an interactive mode comes from [Jest](https://jestjs.io/) an
 
 ## Copyright and License
 
-Copyright (c) 2021-2022 Randy Coulman
+Copyright (c) 2021-2023 Randy Coulman
 
 This work is free. You can redistribute it and/or modify it under the
 terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/lib/mix/tasks/test/interactive.ex
+++ b/lib/mix/tasks/test/interactive.ex
@@ -1,7 +1,70 @@
 defmodule Mix.Tasks.Test.Interactive do
   @shortdoc "Interactively run tests"
   @moduledoc """
-  A task for interactively running tests
+  Interactive test runner for ExUnit tests.
+
+  `mix test.interactive` allows you to easily switch between running all tests,
+  stale tests, or failed tests. Or, you can run only the tests whose filenames
+  contain a substring. Includes an optional "watch mode" which runs tests after
+  every file change.
+
+  ## Usage
+
+  ```shell
+  mix test.interactive [options] pattern...
+  ```
+
+  Your tests will run immediately (and every time a file changes).
+
+  ### Options
+
+  `mix test.interactive` understands the following options:
+  - `--no-watch`: Don't run tests when a file changes
+
+  All other options are passed through to `mix test` on every test run.
+
+  `mix test.interactive` will detect the `--stale` and `--failed` flags and use
+  those as initial settings in interactive mode. You can then toggle those flags
+  on and off as needed.
+
+  ### Patterns and filenames
+
+  `mix test.interactive` can take the same filename or filename:line_number
+  patterns that `mix test` understands. It also allows you to specify one or
+  more "patterns" - strings that match one or more test files. When you provide
+  one or more patterns on the command-line, `mix test.interactive` will find all
+  test files matching those patterns and pass them to `mix test` as if you had
+  used the `p` command (described below).
+
+  ## Interactive Commands
+
+  After the tests run, you can use the interactive mode to change which tests
+  will run.
+
+  - `a`: Run all tests.
+  - `f`: Run only tests that failed on the last run (equivalent to the
+  `--failed` option of `mix test`).
+  - `p`: Run only test files that match one or more provided patterns. A pattern
+  is the project-root-relative path to a test file (with or without a line
+  number specification) or a string that matches a portion of full pathname.
+  e.g. `test/my_project/my_test.exs`, `test/my_project/my_test.exs:12:24` or
+  `my`.
+  - `q`: Exit the program. (Can also use `Ctrl-D`.)
+  - `s`: Run only test files that reference modules that have changed since the
+  last run (equivalent to the `--stale` option of `mix test`).
+  - `w`: Turn file-watching mode on or off.
+  - `Enter`: Re-run the current set of tests without requiring a file change.
+
+  ## Configuration
+
+  If your project has a `config/config.exs` file, you can customize the
+  operation of `mix test.interactive` with the following settings:
+
+  - `clear: true`: Clear the console before each run (default: `false`).
+  - `exclude: [patterns...]`: A list of `Regex`es to ignore when watching for
+    changes (default: `[~r/\.#/, ~r{priv/repo/migrations}]`).
+  - `task: <task name>`: The mix task to use when running tests (default:
+    `"test"`).
   """
 
   use Mix.Task


### PR DESCRIPTION
Now `mix help test.interactive` will show a summary of usage and configuration information for the task.