### PR TITLE
⬆️ Upgrade to latest Elixir version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
             - ~/.mix
       - when:
           condition:
-            equal: ["1.15", << parameters.elixir >>]
+            equal: ["1.16", << parameters.elixir >>]
           steps:
             - run: mix format --check-formatted
       - run: mix test
@@ -37,4 +37,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              elixir: ["1.11", "1.12", "1.13", "1.14", "1.15"]
+              elixir: ["1.12", "1.13", "1.14", "1.15", "1.16"]

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.0.2
-elixir 1.15.5-otp-26
+erlang 26.2.1
+elixir 1.16.0-otp-26


### PR DESCRIPTION
Drop CI support for 1.11 (no longer supported upstream) and add for 1.16.