### PR TITLE
⬇️ Allow file_system 0.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule MixTestInteractive.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.31.1", only: :dev, runtime: false},
-      {:file_system, "~> 1.0"},
+      {:file_system, "~> 0.3 or ~> 1.0"},
       {:styler, "~> 0.11.8", only: [:dev, :test], runtime: false},
       {:temporary_env, "~> 2.0", only: :test},
       {:typed_struct, "~> 0.3.0"}


### PR DESCRIPTION
In #72, we upgraded to file_system 1.0. However, popular libraries like `phoenix_live_reload` still depend on v0.3, which results in a version conflict.

Because this libarary works with either version, we can safely loosen the version specification to avoid conflicts in client projects.