### PR TITLE
⬇️ Allow file_system 0.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule MixTestInteractive.MixProject do
   defp deps do
     [
       {:ex_doc, "~> 0.31.1", only: :dev, runtime: false},
-      {:file_system, "~> 0.3 or ~> 1.0"},
+      {:file_system, "~> 0.2 or ~> 1.0"},
       {:styler, "~> 0.11.8", only: [:dev, :test], runtime: false},
       {:temporary_env, "~> 2.0", only: :test},
       {:typed_struct, "~> 0.3.0"}


### PR DESCRIPTION
There isn't actually a file_system v0.3 version; I was misled by a commit I saw in the phoenix_live_reload repo.

This change allows both v0.2.x and v1.x of file_system to avoid conflicts with other libraries.