### PR TITLE
Update ignored dirs

### DIFF
--- a/lib/mix_test_interactive/paths.ex
+++ b/lib/mix_test_interactive/paths.ex
@@ -4,7 +4,7 @@ defmodule MixTestInteractive.Paths do
   alias MixTestInteractive.Config
 
   @elixir_source_endings ~w(.erl .ex .exs .eex .leex .heex .xrl .yrl .hrl)
-  @ignored_dirs ~w(deps/ _build/)
+  @ignored_dirs ~w(deps/ _build/ .elixir_ls/ .git/)
 
   @doc """
   Determines if we should respond to changes in a file.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MixTestInteractive.MixProject do
   use Mix.Project
 
-  @version "2.0.3"
+  @version "2.0.3-artium.1"
   @source_url "https://github.com/randycoulman/mix_test_interactive"
 
   def project do


### PR DESCRIPTION
Added the .elixir_ls and .git dirs to the list of ignored directories in the Paths module. Otherwise I was getting duplicate runs due to files in the .elixir_ls directory being changed too often during the execution of the tests. I'm not sure *why* files in that directory are getting changed but they are, and this prevents the double test run.