### PR TITLE
Ignore some filesystem events emitted by inotify

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MixTestInteractive.MixProject do
   use Mix.Project
 
-  @version "2.0.3"
+  @version "2.0.4-dev.1"
   @source_url "https://github.com/randycoulman/mix_test_interactive"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MixTestInteractive.MixProject do
   use Mix.Project
 
-  @version "2.0.4-dev.1"
+  @version "2.0.3"
   @source_url "https://github.com/randycoulman/mix_test_interactive"
 
   def project do


### PR DESCRIPTION
The :isdir, :closed, and :attribute events likely don't need to be monitored to run tests, and at least the :attribute event is causing problems for projects that use the Domo library for validation. This is because the Domo library causes a delayed file read event to occur on some elixir files in the lib directory, which causes their atime attribute to be updated. This is happening after the test run kicks off, and then it causes a second test run to occur.