### PR TITLE
💥 Drop support for Elixir 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.12'
-            otp: '24'
           - elixir: '1.13'
             otp: '24'
           - elixir: '1.14'

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule MixTestInteractive.MixProject do
       deps: deps(),
       description: description(),
       docs: docs(),
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       name: "mix test.interactive",
       package: package(),
       source_url: @source_url,


### PR DESCRIPTION
We officially support all [supported Elixir releases](https://hexdocs.pm/elixir/1.17.2/compatibility-and-deprecations.html).

With the release of Elixir 1.17, Elixir 1.12 is no longer supported so we drop support here as well.