### PR TITLE
✨ Allow custom command in place of mix

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 # Used by "mix format"
 [
+  import_deps: [:typed_struct],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   plugins: [Styler]
 ]

--- a/README.md
+++ b/README.md
@@ -72,30 +72,19 @@ mix test.interactive --trace
 
 `mix test.interactive` will detect the `--stale` and `--failed` flags and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed. It will also detect any filename or pattern arguments and use those as initial settings. However, it does not detect any filenames passed with `--include` or `--only`. Note that if you specify a pattern on the command-line, `mix test.interactive` will find all test files matching that pattern and pass those to `mix test` as if you had used the `p` command.
 
-## Running A Different Mix Task
+## Configuration
 
-By default, `mix test.interactive` runs `mix test`. Through the mix config it is possible to run a different mix task. `mix test.interactive` assumes that this alternative task accepts the same command-line arguments as `mix test`.
+`mix test.interactive` can be configured with various options using application
+configuration.
 
-```elixir
-# config/config.exs
-use Mix.Config
-
-if Mix.env == :dev do
-  config :mix_test_interactive,
-    task: "custom_test_task"
-end
-```
-
-The task is run with `MIX_ENV` set to `test`.
-
-## Clearing The Console Before Each Run
+### `clear`: Clear the console before each run
 
 If you want `mix test.interactive` to clear the console before each run, you can
 enable this option in your config/dev.exs as follows:
 
 ```elixir
 # config/config.exs
-use Mix.Config
+import Config
 
 if Mix.env == :dev do
   config :mix_test_interactive,
@@ -103,14 +92,56 @@ if Mix.env == :dev do
 end
 ```
 
-## Excluding files or directories
+### `command`: Use a custom command
 
-To ignore changes from specific files or directories add `exclude:` regexp
-patterns to your config in `mix.exs`:
+By default, `mix test.interactive` uses `mix test` to run tests.
+
+You might want to provide a custom command that does other things before or
+after running `mix`. In that case, you can customize the command used for
+running tests.
+
+For example, you might want to provide a name for the test runner process to
+allow connection from other Erlang nodes. Or you might want to run other
+commands before or after running the tests.
+
+In those cases, you can customize the command that `mix test.interactive` will
+use to run your tests. `mix test.interactive` assumes that the custom command
+ultimately runs `mix` under the hood (or at least accepts
+all of the same command-line arguments as `mix`). The custom command can either be a string or
+a `{command, [..args..]}` tuple.
+
+Examples:
 
 ```elixir
 # config/config.exs
-use Mix.Config
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    command: "path/to/my/test_runner.sh"
+end
+```
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    command: {"elixir", ["--sname", "name", "-S", "mix"]}
+end
+```
+
+To run a different mix task instead, see the `task` option below.
+
+### `exclude`: Excluding files or directories
+
+To stop changes to specific files or directories from triggering test runs, you
+can add `exclude:` regexp patterns to your config in `mix.exs`:
+
+```elixir
+# config/config.exs
+import Config
 
 if Mix.env == :dev do
   config :mix_test_interactive,
@@ -120,6 +151,84 @@ end
 ```
 
 The default is `exclude: [~r/\.#/, ~r{priv/repo/migrations}]`.
+
+### `extra_extensions`: Watch files with additional extensions
+
+By default, `mix test.interactive` will trigger a test run when a known Elixir
+or Erlang file has changed, but not when any other file changes.
+
+You can specify additional file extensions to be included with the
+`extra_extensions` option.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    extra_extensions: ["json"]
+end
+```
+
+`mix test.interactive` always watches files with the following extensions:
+`.erl`, `.ex`, `.exs`, `.eex`, `.leex`, `.heex`, `.xrl`, `.yrl`, and `.hrl`. To
+ignore files with any of these extensions, you can specify an `exclude` regexp
+(see above).
+
+### `runner`: Use a custom runner module
+
+By default `mix test.interactive` uses an internal module named
+`MixTestInteractive.PortRunner` to run the tests. If you want to
+run the tests in a different way, you can supply your own runner module instead.
+Your module must implement a `run/2` function that takes a
+`MixTestInteractive.Config` struct and a list of `String.t()` arguments.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    runner: MyApp.FancyTestRunner
+end
+```
+
+### `timestamp`: Display the current time before running the tests
+
+When `timestamp` is set to true, `mix test.interactive` will display the
+current time (UTC) just before running the tests.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    timestamp: true
+end
+```
+
+### `task`: Run a different mix task
+
+By default, `mix test.interactive` runs `mix test`.
+
+Through the mix config it is possible to run a different mix task. `mix
+test.interactive` assumes that this alternative task accepts the same
+command-line arguments as `mix test`.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    task: "custom_test_task"
+end
+```
+
+The task is run with `MIX_ENV` set to `test`.
+
+To use a custom command instead, see the `command` option above.
 
 ## Compatibility Notes
 

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -5,20 +5,22 @@ defmodule MixTestInteractive.Config do
 
   use TypedStruct
 
-  @default_runner MixTestInteractive.PortRunner
-  @default_task "test"
   @default_clear false
-  @default_show_timestamp false
+  @default_command {"mix", []}
   @default_exclude [~r/\.#/, ~r{priv/repo/migrations}]
   @default_extra_extensions []
+  @default_runner MixTestInteractive.PortRunner
+  @default_show_timestamp false
+  @default_task "test"
 
   typedstruct do
-    field(:clear?, boolean, default: @default_clear)
-    field(:exclude, [Regex.t()], default: @default_exclude)
-    field(:extra_extensions, [String.t()], default: @default_extra_extensions)
-    field(:runner, module(), default: @default_runner)
-    field(:show_timestamp?, boolean(), default: @default_show_timestamp)
-    field(:task, String.t(), default: @default_task)
+    field :clear?, boolean, default: @default_clear
+    field :command, {String.t(), [String.t()]}, default: @default_command
+    field :exclude, [Regex.t()], default: @default_exclude
+    field :extra_extensions, [String.t()], default: @default_extra_extensions
+    field :runner, module(), default: @default_runner
+    field :show_timestamp?, boolean(), default: @default_show_timestamp
+    field :task, String.t(), default: @default_task
   end
 
   @application :mix_test_interactive
@@ -30,6 +32,7 @@ defmodule MixTestInteractive.Config do
   def new do
     %__MODULE__{
       clear?: get_clear(),
+      command: get_command(),
       exclude: get_excluded(),
       extra_extensions: get_extra_extensions(),
       runner: get_runner(),
@@ -38,20 +41,16 @@ defmodule MixTestInteractive.Config do
     }
   end
 
-  defp get_runner do
-    Application.get_env(@application, :runner, @default_runner)
-  end
-
-  defp get_task do
-    Application.get_env(@application, :task, @default_task)
-  end
-
   defp get_clear do
     Application.get_env(@application, :clear, @default_clear)
   end
 
-  defp get_show_timestamp do
-    Application.get_env(@application, :timestamp, @default_show_timestamp)
+  defp get_command do
+    case Application.get_env(@application, :command, @default_command) do
+      {cmd, args} = command when is_binary(cmd) and is_list(args) -> command
+      command when is_binary(command) -> {command, []}
+      _invalid_command -> raise ArgumentError, "command must be a binary or a {command, [arg, ...]} tuple"
+    end
   end
 
   defp get_excluded do
@@ -60,5 +59,17 @@ defmodule MixTestInteractive.Config do
 
   defp get_extra_extensions do
     Application.get_env(@application, :extra_extensions, @default_extra_extensions)
+  end
+
+  defp get_runner do
+    Application.get_env(@application, :runner, @default_runner)
+  end
+
+  defp get_show_timestamp do
+    Application.get_env(@application, :timestamp, @default_show_timestamp)
+  end
+
+  defp get_task do
+    Application.get_env(@application, :task, @default_task)
   end
 end

--- a/lib/mix_test_interactive/settings.ex
+++ b/lib/mix_test_interactive/settings.ex
@@ -14,12 +14,12 @@ defmodule MixTestInteractive.Settings do
   @default_list_all_files &TestFiles.list/0
 
   typedstruct do
-    field(:failed?, boolean(), default: false)
-    field(:initial_cli_args, [String.t()], default: [])
-    field(:list_all_files, (-> [String.t()]), default: @default_list_all_files)
-    field(:patterns, [String.t()], default: [])
-    field(:stale?, boolean(), default: false)
-    field(:watching?, boolean(), default: true)
+    field :failed?, boolean(), default: false
+    field :initial_cli_args, [String.t()], default: []
+    field :list_all_files, (-> [String.t()]), default: @default_list_all_files
+    field :patterns, [String.t()], default: []
+    field :stale?, boolean(), default: false
+    field :watching?, boolean(), default: true
   end
 
   @options [

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -5,18 +5,42 @@ defmodule MixTestInteractive.ConfigTest do
   alias MixTestInteractive.Config
 
   describe "creation" do
-    test "takes :task from the env" do
-      TemporaryEnv.put :mix_test_interactive, :task, :env_task do
+    test "takes :clear? from the env" do
+      TemporaryEnv.put :mix_test_interactive, :clear, true do
         config = Config.new()
-        assert config.task == :env_task
+        assert config.clear?
       end
     end
 
-    test ~s(defaults :task to "test") do
-      TemporaryEnv.delete :mix_test_interactive, :task do
+    test "takes :command as a string from the env" do
+      command = "/path/to/command"
+
+      TemporaryEnv.put :mix_test_interactive, :command, command do
         config = Config.new()
-        assert config.task == "test"
+        assert config.command == {command, []}
       end
+    end
+
+    test "takes :command as a tuple from the env" do
+      command = {"command", ["arg1", "arg2"]}
+
+      TemporaryEnv.put :mix_test_interactive, :command, command do
+        config = Config.new()
+        assert config.command == command
+      end
+    end
+
+    test "raises an error if :command is invalid" do
+      TemporaryEnv.put :mix_test_interactive, :command, ["invalid_command", "arg1", "arg2"] do
+        assert_raise ArgumentError, fn ->
+          Config.new()
+        end
+      end
+    end
+
+    test "defaults :command to `{\"mix\", []}`" do
+      config = Config.new()
+      assert config.command == {"mix", []}
     end
 
     test "takes :exclude from the env" do
@@ -44,17 +68,24 @@ defmodule MixTestInteractive.ConfigTest do
       end
     end
 
-    test "takes :clear? from the env" do
-      TemporaryEnv.put :mix_test_interactive, :clear, true do
-        config = Config.new()
-        assert config.clear?
-      end
-    end
-
     test "takes :show_timestamps? from the env" do
       TemporaryEnv.put :mix_test_interactive, :timestamp, true do
         config = Config.new()
         assert config.show_timestamp?
+      end
+    end
+
+    test "takes :task from the env" do
+      TemporaryEnv.put :mix_test_interactive, :task, :env_task do
+        config = Config.new()
+        assert config.task == :env_task
+      end
+    end
+
+    test ~s(defaults :task to "test") do
+      TemporaryEnv.delete :mix_test_interactive, :task do
+        config = Config.new()
+        assert config.task == "test"
       end
     end
   end

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -42,6 +42,21 @@ defmodule MixTestInteractive.PortRunnerTest do
       config = %Config{task: "custom"}
       assert {_command, ["custom"], _options} = run_windows(config: config)
     end
+
+    test "uses custom command with no args" do
+      config = %Config{command: {"custom_command", []}}
+      assert {"custom_command", _args, _options} = run_windows(config: config)
+    end
+
+    test "uses custom command with args" do
+      config = %Config{command: {"custom_command", ["--custom_arg"]}}
+      assert {"custom_command", ["--custom_arg", "test"], _options} = run_windows(config: config)
+    end
+
+    test "prepends command args to other args" do
+      config = %Config{command: {"custom_command", ["--custom_arg"]}}
+      assert {_command, ["--custom_arg", "test", "--cover"], _options} = run_windows(args: ["--cover"], config: config)
+    end
   end
 
   describe "running on Unix-like operating systems" do
@@ -75,6 +90,33 @@ defmodule MixTestInteractive.PortRunnerTest do
       {_command, args, _options} = run_unix(config: config)
 
       assert List.last(args) == "custom"
+    end
+
+    test "uses custom command with no args" do
+      config = %Config{command: {"custom_command", []}}
+
+      {_command, args, _options} = run_unix(config: config)
+
+      assert List.first(args) == "custom_command"
+      assert List.last(args) == "test"
+    end
+
+    test "uses custom command with args" do
+      config = %Config{command: {"custom_command", ["--custom_arg"]}}
+
+      {_command, args, _options} = run_unix(config: config)
+
+      assert List.first(args) == "custom_command"
+      assert Enum.take(args, -2) == ["--custom_arg", "test"]
+    end
+
+    test "prepends command args to other args" do
+      config = %Config{command: {"custom_command", ["--custom_arg"]}}
+
+      {_command, args, _options} = run_unix(args: ["--cover"], config: config)
+
+      assert List.first(args) == "custom_command"
+      assert Enum.take(args, -3) == ["--custom_arg", "test", "--cover"]
     end
   end
 end

--- a/test/mix_test_interactive/runner_test.exs
+++ b/test/mix_test_interactive/runner_test.exs
@@ -1,5 +1,5 @@
 defmodule MixTestInteractive.RunnerTest do
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   import ExUnit.CaptureIO
 


### PR DESCRIPTION
Allow a custom command (with optional arguments) to be used in place of `mix`.

Also:
- Some code cleanups
- Add documentation for all configuration options (several were missing previously)

Closes #63