### PR TITLE
✨ Make pattern filtering more flexible

### DIFF
--- a/lib/mix_test_interactive/pattern_filter.ex
+++ b/lib/mix_test_interactive/pattern_filter.ex
@@ -18,15 +18,11 @@ defmodule MixTestInteractive.PatternFilter do
   end
 
   def matches(files, patterns) do
-    if any_line_number_patterns?(patterns) do
-      patterns
-    else
-      Enum.filter(files, &String.contains?(&1, patterns))
-    end
-  end
+    {with_line_number, simple} = Enum.split_with(patterns, &is_line_number_pattern?/1)
 
-  defp any_line_number_patterns?(patterns) do
-    Enum.any?(patterns, &is_line_number_pattern?/1)
+    files
+    |> Enum.filter(&String.contains?(&1, simple))
+    |> Kernel.++(with_line_number)
   end
 
   defp is_line_number_pattern?(pattern) do

--- a/test/mix_test_interactive/pattern_filter_test.exs
+++ b/test/mix_test_interactive/pattern_filter_test.exs
@@ -27,10 +27,17 @@ defmodule MixTestInteractive.PatternFilterTest do
     assert matches == [@abc, @cde]
   end
 
-  test "returns only patterns if any is a file with line number" do
-    patterns = ["a", "some_test.exs:42"]
+  test "returns multiple file with line number patterns" do
+    patterns = ["some_test.exs:42", "other_test.exs:58"]
     matches = PatternFilter.matches(@files, patterns)
 
     assert matches == patterns
+  end
+
+  test "returns a mix of matching files and files with line numbers" do
+    patterns = ["some_test.exs:42", "bc", "other_test.exs:58"]
+    matches = PatternFilter.matches(@files, patterns)
+
+    assert matches == [@abc, @bcd, "some_test.exs:42", "other_test.exs:58"]
   end
 end


### PR DESCRIPTION
Previously, when given multiple patterns, we would not do any file filtering if any of the patterns was a `file:line`-style pattern. Instead, we'd pass all of the patterns to `mix test` literally.

Now, we run normal file filtering for any non-`file:line`-style patterns and concatenate the results with any `file:line`-style patterns.