### PR TITLE
📝 Add all config options to mix task docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,21 +193,6 @@ if Mix.env == :dev do
 end
 ```
 
-### `timestamp`: Display the current time before running the tests
-
-When `timestamp` is set to true, `mix test.interactive` will display the
-current time (UTC) just before running the tests.
-
-```elixir
-# config/config.exs
-import Config
-
-if Mix.env == :dev do
-  config :mix_test_interactive,
-    timestamp: true
-end
-```
-
 ### `task`: Run a different mix task
 
 By default, `mix test.interactive` runs `mix test`.
@@ -229,6 +214,21 @@ end
 The task is run with `MIX_ENV` set to `test`.
 
 To use a custom command instead, see the `command` option above.
+
+### `timestamp`: Display the current time before running the tests
+
+When `timestamp` is set to true, `mix test.interactive` will display the
+current time (UTC) just before running the tests.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    timestamp: true
+end
+```
 
 ## Compatibility Notes
 

--- a/lib/mix/tasks/test/interactive.ex
+++ b/lib/mix/tasks/test/interactive.ex
@@ -61,10 +61,18 @@ defmodule Mix.Tasks.Test.Interactive do
   operation of `mix test.interactive` with the following settings:
 
   - `clear: true`: Clear the console before each run (default: `false`).
+  - `command: <program>` or `command: {<program>, [<arg>, ...]}`:
+    Use the provided command and arguments to run the test task (default: `mix`).
   - `exclude: [patterns...]`: A list of `Regex`es to ignore when watching for
     changes (default: `[~r/\.#/, ~r{priv/repo/migrations}]`).
+  - `extra_extensions: [<ext>...]`: Additional filename extensions to include
+    when watching for file changes (default: `[]`).
+  - `runner: <module>`: A custom runner for running the tests (default:
+    `MixTestInteractive.PortRunner`).
   - `task: <task name>`: The mix task to use when running tests (default:
     `"test"`).
+  - `timestamp: true`: Print current time (UTC) before running tests (default:
+    false).
   """
 
   use Mix.Task


### PR DESCRIPTION
Earlier, we added missing documentation for configuration options to the README, but forgot to add them to the mix task's `@moduledoc`. This corrects that oversight.