### PR TITLE
Assemble commands correctly on Unix-like systems.

### DIFF
--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -75,7 +75,7 @@ defmodule MixTestInteractive.PortRunnerTest do
     test "includes no-start flag in ansi command" do
       assert {_command, args, _options} = run_unix(args: ["--no-start"])
 
-      assert ["mix", "do", "run", "--no-start", "-e", _ansi, ",", "test", "--no-start"] = args
+      assert ["mix", "do", "run", "--no-start", "-e", _ansi, ",", "test"] = args
     end
 
     test "appends extra command-line arguments from settings" do
@@ -102,12 +102,12 @@ defmodule MixTestInteractive.PortRunnerTest do
     end
 
     test "uses custom command with args" do
-      config = %Config{command: {"custom_command", ["--custom_arg"]}}
+      # custom command == "elixir"
+      config = %Config{command: {"elixir", ["--sname", "node-name", "-S", "mix"]}}
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert List.first(args) == "custom_command"
-      assert Enum.take(args, -2) == ["--custom_arg", "test"]
+      assert ["elixir", "--sname", "node-name", "-S", "mix", "do", "run", "-e", _ansi, ",", "test"] = args
     end
 
     test "prepends command args to other args" do
@@ -115,8 +115,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
       {_command, args, _options} = run_unix(args: ["--cover"], config: config)
 
-      assert List.first(args) == "custom_command"
-      assert Enum.take(args, -3) == ["--custom_arg", "test", "--cover"]
+      assert ["custom_command", "--custom_arg", "do", "run", "-e", _ansi, ",", "test", "--cover"] = args
     end
   end
 end

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -33,9 +33,7 @@ defmodule MixTestInteractive.PortRunnerTest do
     end
 
     test "appends extra command-line arguments" do
-      {_command, args, _options} = run_windows(args: ["--cover"])
-
-      assert List.last(args) == "--cover"
+      assert {"mix", ["test", "--cover"], _options} = run_windows(args: ["--cover"])
     end
 
     test "uses custom task" do
@@ -53,9 +51,11 @@ defmodule MixTestInteractive.PortRunnerTest do
       assert {"custom_command", ["--custom_arg", "test"], _options} = run_windows(config: config)
     end
 
-    test "prepends command args to other args" do
+    test "prepends command args to test args" do
       config = %Config{command: {"custom_command", ["--custom_arg"]}}
-      assert {_command, ["--custom_arg", "test", "--cover"], _options} = run_windows(args: ["--cover"], config: config)
+
+      assert {"custom_command", ["--custom_arg", "test", "--cover"], _options} =
+               run_windows(args: ["--cover"], config: config)
     end
   end
 
@@ -81,15 +81,15 @@ defmodule MixTestInteractive.PortRunnerTest do
     test "appends extra command-line arguments from settings" do
       {_command, args, _options} = run_unix(args: ["--cover"])
 
-      assert List.last(args) == "--cover"
+      assert ["mix", "do", "run", "-e", _ansi, ",", "test", "--cover"] = args
     end
 
     test "uses custom task" do
-      config = %Config{task: "custom"}
+      config = %Config{task: "custom_task"}
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert List.last(args) == "custom"
+      assert ["mix", "do", "run", "-e", _ansi, ",", "custom_task"] = args
     end
 
     test "uses custom command with no args" do
@@ -97,20 +97,18 @@ defmodule MixTestInteractive.PortRunnerTest do
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert List.first(args) == "custom_command"
-      assert List.last(args) == "test"
+      assert ["custom_command", "do", "run", "-e", _ansi, ",", "test"] = args
     end
 
     test "uses custom command with args" do
-      # custom command == "elixir"
-      config = %Config{command: {"elixir", ["--sname", "node-name", "-S", "mix"]}}
+      config = %Config{command: {"custom_command", ["--custom_arg"]}}
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert ["elixir", "--sname", "node-name", "-S", "mix", "do", "run", "-e", _ansi, ",", "test"] = args
+      assert ["custom_command", "--custom_arg", "do", "run", "-e", _ansi, ",", "test"] = args
     end
 
-    test "prepends command args to other args" do
+    test "prepends command args to test args" do
       config = %Config{command: {"custom_command", ["--custom_arg"]}}
 
       {_command, args, _options} = run_unix(args: ["--cover"], config: config)


### PR DESCRIPTION
Given a configuration such as:

```elixir
config :mix_test_interactive,
    command: {"elixir", ["--sname", "name", "-S", "mix"]}
```

Old MixTestInteractive.PortRunner.run/4 will pass the following options to the runner_program:

```elixir
["elixir", "do", "run", "-e", "Application.put_env(:elixir, :ansi_enabled, true);", ",", "--sname", "my-node", "-S", "mix", "test"]
```

Which will cause user to get `no file named "do"` error.

This pull request assembles the command properly so we pass to runner_program:

```elixir
["elixir", "--sname", "my-node", "-S", "mix", "do", "run", "-e", "Application.put_env(:elixir, :ansi_enabled, true);", ",", "test"]
```