### PR TITLE
🚸 Colorize the `Running tests...` message

### DIFF
--- a/lib/mix_test_interactive/runner.ex
+++ b/lib/mix_test_interactive/runner.ex
@@ -13,7 +13,13 @@ defmodule MixTestInteractive.Runner do
   @spec run(Config.t(), [String.t()]) :: :ok
   def run(config, args) do
     :ok = maybe_clear_terminal(config)
-    IO.puts("\nRunning tests...")
+
+    IO.puts("")
+
+    [:cyan, :bright, "Running tests..."]
+    |> IO.ANSI.format()
+    |> IO.puts()
+
     :ok = maybe_print_timestamp(config)
     config.runner.run(config, args)
   end

--- a/test/mix_test_interactive/runner_test.exs
+++ b/test/mix_test_interactive/runner_test.exs
@@ -30,10 +30,7 @@ defmodule MixTestInteractive.RunnerTest do
 
       assert Agent.get(DummyRunner, fn x -> x end) == [{config, args}]
 
-      assert output == """
-
-             Running tests...
-             """
+      assert output =~ "Running tests..."
     end
 
     test "It outputs timestamp when specified by the config" do
@@ -48,14 +45,8 @@ defmodule MixTestInteractive.RunnerTest do
 
       timestamp =
         output
-        |> String.replace_leading(
-          """
-
-          Running tests...
-          """,
-          ""
-        )
-        |> String.trim()
+        |> String.split("\n", trim: true)
+        |> List.last()
 
       assert {:ok, _} = NaiveDateTime.from_iso8601(timestamp)
     end


### PR DESCRIPTION
This makes it easier to find when scrolling back.