### PR TITLE
✨ Add `d` command for setting/clearing the test seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # mix test.interactive
 
-[![Build Status](https://github.com/randycoulman/mix_test_interactive/actions/workflows/ci.yml/badge.svg)](https://github.com/randycoulman/mix_test_interactive/actions)
-[![Module Version](https://img.shields.io/hexpm/v/mix_test_interactive.svg)](https://hex.pm/packages/mix_test_interactive)
-[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/mix_test_interactive/)
+[![Build
+Status](https://github.com/randycoulman/mix_test_interactive/actions/workflows/ci.yml/badge.svg)](https://github.com/randycoulman/mix_test_interactive/actions)
+[![Module
+Version](https://img.shields.io/hexpm/v/mix_test_interactive.svg)](https://hex.pm/packages/mix_test_interactive)
+[![Hex
+Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/mix_test_interactive/)
 [![License](https://img.shields.io/hexpm/l/mix_test_interactive.svg)](https://github.com/randycoulman/mix_test_interactive/blob/master/LICENSE.md)
 
 `mix test.interactive` is an interactive test runner for ExUnit tests.
 
-Based on Louis Pilfold's wonderful [mix-test.watch](https://github.com/lpil/mix-test.watch) and inspired by Jest's interactive watch mode, `mix test.interactive` allows you to dynamically change which tests should be run with a few keystrokes.
+Based on Louis Pilfold's wonderful
+[mix-test.watch](https://github.com/lpil/mix-test.watch) and inspired by Jest's
+interactive watch mode, `mix test.interactive` allows you to dynamically change
+which tests should be run with a few keystrokes.
 
-It allows you to easily switch between running all tests, stale tests, or failed tests. Or, you can run only the tests whose filenames contain a substring. Includes an optional "watch mode" which runs tests after every file change.
+It allows you to easily switch between running all tests, stale tests, or failed
+tests. Or, you can run only the tests whose filenames contain a substring.
+Includes an optional "watch mode" which runs tests after every file change.
 
 ## Installation
 
-The package can be installed by adding `mix_test_interactive` to your list of dependencies in `mix.exs`:
+The package can be installed by adding `mix_test_interactive` to your list of
+dependencies in `mix.exs`:
 
 ```elixir
 def deps do
@@ -46,9 +55,9 @@ If an option is provided on the command line, it will override the same option
 specified in the configuration.
 
 - `--(no-)clear`: Clear the console before each run (default `false`).
-- `--command <command> [--arg <arg>]`: Custom command and arguments for
-  running tests (default: "mix" with no arguments). NOTE: Use `--arg` multiple
-  times to specify more than one argument.
+- `--command <command> [--arg <arg>]`: Custom command and arguments for running
+  tests (default: "mix" with no arguments). NOTE: Use `--arg` multiple times to
+  specify more than one argument.
 - `--exclude <regex>`: Exclude files/directories from triggering test runs
   (default: `["~r/\.#/", "~r{priv/repo/migrations}"`]) NOTE: Use `--exclude`
   multiple times to specify more than one regex.
@@ -61,23 +70,35 @@ specified in the configuration.
   (default: `false`).
 - `--(no-)watch`: Don't run tests when a file changes (default: `true`).
 
-All of the `<mix test arguments>` are passed through to `mix test` on every
-test run.
+All of the `<mix test arguments>` are passed through to `mix test` on every test
+run.
 
-`mix test.interactive` will detect the `--stale` and `--failed` flags and use those as initial settings in interactive mode. You can then toggle those flags on and off as needed. It will also detect any filename or pattern arguments and use those as initial settings. However, it does not detect any filenames passed with `--include` or `--only`. Note that if you specify a pattern on the command-line, `mix test.interactive` will find all test files matching that pattern and pass those to `mix test` as if you had used the `p` command.
+`mix test.interactive` will detect the `--failed`, `--seed`, and `--stale`
+options and use those as initial settings in interactive mode. You can then use
+the interactive mode commands to adjust those options as needed. It will also
+detect any filename or pattern arguments and use those as initial settings.
+However, it does not detect any filenames passed with `--include` or `--only`.
+Note that if you specify a pattern on the command-line, `mix test.interactive`
+will find all test files matching that pattern and pass those to `mix test` as
+if you had used the `p` command.
 
 ### Patterns and filenames
 
 `mix test.interactive` can take the same filename or filename:line_number
-patterns that `mix test` understands. It also allows you to specify one or
-more "patterns" - strings that match one or more test files. When you provide
-one or more patterns on the command-line, `mix test.interactive` will find all
-test files matching those patterns and pass them to `mix test` as if you had
-used the `p` command (described below).
+patterns that `mix test` understands. It also allows you to specify one or more
+"patterns" - strings that match one or more test files. When you provide one or
+more patterns on the command-line, `mix test.interactive` will find all test
+files matching those patterns and pass them to `mix test` as if you had used the
+`p` command (described below).
 
-After the tests run, you can use the interactive mode to change which tests will run.
+After the tests run, you can use the interactive mode to change which tests will
+run.
 
-Use the `p` command to run only test files that match one or more provided patterns. A pattern is the project-root-relative path to a test file (with or without a line number specification) or a string that matches a portion of full pathname. e.g. `test/my_project/my_test.exs`, `test/my_project/my_test.exs:12:24` or `my`.
+Use the `p` command to run only test files that match one or more provided
+patterns. A pattern is the project-root-relative path to a test file (with or
+without a line number specification) or a string that matches a portion of full
+pathname. e.g. `test/my_project/my_test.exs`,
+`test/my_project/my_test.exs:12:24` or `my`.
 
 Any patterns that contain a line number specification are passed directly to
 `mix test`. Remaining patterns are matched against test filenames as above.
@@ -86,15 +107,22 @@ Any patterns that contain a line number specification are passed directly to
 p pattern1 pattern2
 ```
 
-Use the `s` command to run only test files that reference modules that have changed since the last run (equivalent to the `--stale` option of `mix test`).
+Use the `s` command to run only test files that reference modules that have
+changed since the last run (equivalent to the `--stale` option of `mix test`).
 
-Use the `f` command to run only tests that failed on the last run (equivalent to the `--failed` option of `mix test`).
+Use the `f` command to run only tests that failed on the last run (equivalent to
+the `--failed` option of `mix test`).
 
-Use the `a` command to run all tests.
+Use the `a` command to run all tests, turning off the `--failed` and `--stale`
+flags as well as clearing any patterns.
+
+Use the `d <seed>` command to run tests with a specific seed, and then use `d`
+(with no seed) to remove the seed.
 
 Use the `w` command to turn file-watching mode on or off.
 
-Use the `Enter` key to re-run the current set of tests without requiring a file change.
+Use the `Enter` key to re-run the current set of tests without requiring a file
+change.
 
 Use the `q` command, or press `Ctrl-D` to exit the program.
 
@@ -133,9 +161,9 @@ commands before or after running the tests.
 
 In those cases, you can customize the command that `mix test.interactive` will
 use to run your tests. `mix test.interactive` assumes that the custom command
-ultimately runs `mix` under the hood (or at least accepts
-all of the same command-line arguments as `mix`). The custom command can either be a string or
-a `{command, [..args..]}` tuple.
+ultimately runs `mix` under the hood (or at least accepts all of the same
+command-line arguments as `mix`). The custom command can either be a string or a
+`{command, [..args..]}` tuple.
 
 Examples:
 
@@ -205,10 +233,10 @@ ignore files with any of these extensions, you can specify an `exclude` regexp
 ### `runner`: Use a custom runner module
 
 By default `mix test.interactive` uses an internal module named
-`MixTestInteractive.PortRunner` to run the tests. If you want to
-run the tests in a different way, you can supply your own runner module instead.
-Your module must implement a `run/2` function that takes a
-`MixTestInteractive.Config` struct and a list of `String.t()` arguments.
+`MixTestInteractive.PortRunner` to run the tests. If you want to run the tests
+in a different way, you can supply your own runner module instead. Your module
+must implement a `run/2` function that takes a `MixTestInteractive.Config`
+struct and a list of `String.t()` arguments.
 
 ```elixir
 # config/config.exs
@@ -244,8 +272,8 @@ To use a custom command instead, see the `command` option above.
 
 ### `timestamp`: Display the current time before running the tests
 
-When `timestamp` is set to true, `mix test.interactive` will display the
-current time (UTC) just before running the tests.
+When `timestamp` is set to true, `mix test.interactive` will display the current
+time (UTC) just before running the tests.
 
 ```elixir
 # config/config.exs
@@ -268,13 +296,17 @@ You can enable desktop notifications with
 
 ## Acknowledgements
 
-This project started as a clone of the wonderful [mix-test.watch](https://github.com/lpil/mix-test.watch) project, which I've used and loved for years. I've added the interactive mode features to the existing feature set.
+This project started as a clone of the wonderful
+[mix-test.watch](https://github.com/lpil/mix-test.watch) project, which I've
+used and loved for years. I've added the interactive mode features to the
+existing feature set.
 
-The idea for having an interactive mode comes from [Jest](https://jestjs.io/) and its incredibly useful interactive watch mode.
+The idea for having an interactive mode comes from [Jest](https://jestjs.io/)
+and its incredibly useful interactive watch mode.
 
 ## Copyright and License
 
 Copyright (c) 2021-2024 Randy Coulman
 
-This work is free. You can redistribute it and/or modify it under the
-terms of the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.
+This work is free. You can redistribute it and/or modify it under the terms of
+the MIT License. See the [LICENSE.md](./LICENSE.md) file for more details.

--- a/lib/mix/tasks/test/interactive.ex
+++ b/lib/mix/tasks/test/interactive.ex
@@ -49,9 +49,9 @@ defmodule Mix.Tasks.Test.Interactive do
   All of the `<mix test arguments>` are passed through to `mix test` on every
   test run.
 
-  `mix test.interactive` will detect the `--stale` and `--failed` flags and use
-  those as initial settings in interactive mode. You can then toggle those flags
-  on and off as needed.
+  `mix test.interactive` will detect the `--failed`, `--seed`, and `--stale`
+  options and use those as initial settings in interactive mode. You can then
+  use the interactive mode commands to adjust those options as needed.
 
   ### Patterns and filenames
 
@@ -67,17 +67,20 @@ defmodule Mix.Tasks.Test.Interactive do
   After the tests run, you can use the interactive mode to change which tests
   will run.
 
-  - `a`: Run all tests.
+  - `a`: Run all tests. Clears the `--failed` and `--stale` options as well as
+    any patterns.
+  - `d <seed>`: Run the tests with a specific seed.
+  - `d`: Clear any previously specified seed.
   - `f`: Run only tests that failed on the last run (equivalent to the
   `--failed` option of `mix test`).
   - `p`: Run only test files that match one or more provided patterns. A pattern
-  is the project-root-relative path to a test file (with or without a line
-  number specification) or a string that matches a portion of full pathname.
-  e.g. `test/my_project/my_test.exs`, `test/my_project/my_test.exs:12:24` or
-  `my`.
+    is the project-root-relative path to a test file (with or without a line
+    number specification) or a string that matches a portion of full pathname.
+    e.g. `test/my_project/my_test.exs`, `test/my_project/my_test.exs:12:24` or
+    `my`.
   - `q`: Exit the program. (Can also use `Ctrl-D`.)
   - `s`: Run only test files that reference modules that have changed since the
-  last run (equivalent to the `--stale` option of `mix test`).
+    last run (equivalent to the `--stale` option of `mix test`).
   - `w`: Turn file-watching mode on or off.
   - `Enter`: Re-run the current set of tests without requiring a file change.
 

--- a/lib/mix_test_interactive/command/seed.ex
+++ b/lib/mix_test_interactive/command/seed.ex
@@ -1,0 +1,25 @@
+defmodule MixTestInteractive.Command.Seed do
+  @moduledoc """
+  Specify or clear the random number seed for test runs.
+
+  Runs the tests with the given seed if provided. If not provided, the seed is
+  cleared and the tests will run with a random seed as usual.
+  """
+  use MixTestInteractive.Command, command: "d", desc: "set or clear the test seed"
+
+  alias MixTestInteractive.Command
+  alias MixTestInteractive.Settings
+
+  @impl Command
+  def name, do: "d [<seed>]"
+
+  @impl Command
+  def run([], %Settings{} = settings) do
+    {:ok, Settings.clear_seed(settings)}
+  end
+
+  @impl Command
+  def run([seed], %Settings{} = settings) do
+    {:ok, Settings.with_seed(settings, seed)}
+  end
+end

--- a/lib/mix_test_interactive/command_line_parser.ex
+++ b/lib/mix_test_interactive/command_line_parser.ex
@@ -164,6 +164,7 @@ defmodule MixTestInteractive.CommandLineParser do
   defp build_settings(mti_opts, mix_test_opts, patterns) do
     no_patterns? = Enum.empty?(patterns)
     {failed?, mix_test_opts} = Keyword.pop(mix_test_opts, :failed, false)
+    {seed, mix_test_opts} = Keyword.pop(mix_test_opts, :seed)
     {stale?, mix_test_opts} = Keyword.pop(mix_test_opts, :stale, false)
     watching? = Keyword.get(mti_opts, :watch, true)
 
@@ -171,6 +172,7 @@ defmodule MixTestInteractive.CommandLineParser do
       failed?: no_patterns? && failed?,
       initial_cli_args: OptionParser.to_argv(mix_test_opts),
       patterns: patterns,
+      seed: seed && to_string(seed),
       stale?: no_patterns? && !failed? && stale?,
       watching?: watching?
     }

--- a/lib/mix_test_interactive/command_processor.ex
+++ b/lib/mix_test_interactive/command_processor.ex
@@ -10,6 +10,7 @@ defmodule MixTestInteractive.CommandProcessor do
   alias MixTestInteractive.Command.Pattern
   alias MixTestInteractive.Command.Quit
   alias MixTestInteractive.Command.RunTests
+  alias MixTestInteractive.Command.Seed
   alias MixTestInteractive.Command.Stale
   alias MixTestInteractive.Command.ToggleWatchMode
   alias MixTestInteractive.Settings
@@ -17,14 +18,15 @@ defmodule MixTestInteractive.CommandProcessor do
   @type response :: Command.response()
 
   @commands [
-    Pattern,
-    Stale,
-    Failed,
     AllTests,
-    ToggleWatchMode,
-    RunTests,
+    Failed,
     Help,
-    Quit
+    Pattern,
+    Quit,
+    RunTests,
+    Seed,
+    Stale,
+    ToggleWatchMode
   ]
 
   @doc """

--- a/test/mix_test_interactive/command_line_parser_test.exs
+++ b/test/mix_test_interactive/command_line_parser_test.exs
@@ -208,6 +208,12 @@ defmodule MixTestInteractive.CommandLineParserTest do
       assert settings.initial_cli_args == ["--trace", "--raise"]
     end
 
+    test "extracts seed from arguments" do
+      {:ok, %{settings: settings}} = CommandLineParser.parse(["--trace", "--seed", "5432", "--raise"])
+      assert settings.seed == "5432"
+      assert settings.initial_cli_args == ["--trace", "--raise"]
+    end
+
     test "extracts patterns from arguments" do
       {:ok, %{settings: settings}} = CommandLineParser.parse(["pattern1", "--trace", "pattern2"])
       assert settings.patterns == ["pattern1", "pattern2"]

--- a/test/mix_test_interactive/command_processor_test.exs
+++ b/test/mix_test_interactive/command_processor_test.exs
@@ -22,6 +22,34 @@ defmodule MixTestInteractive.CommandProcessorTest do
       assert {:ok, ^settings} = process_command("", settings)
     end
 
+    test "a runs all tests" do
+      {:ok, settings} = process_command("s", %Settings{})
+      expected = Settings.all_tests(settings)
+
+      assert {:ok, ^expected} = process_command("a", settings)
+    end
+
+    test "d <seed> sets the test seed" do
+      settings = %Settings{}
+      expected = Settings.with_seed(settings, "4258")
+
+      assert {:ok, ^expected} = process_command("d 4258", settings)
+    end
+
+    test "d with no seed clears the test seed" do
+      {:ok, settings} = process_command("d 1234", %Settings{})
+      expected = Settings.clear_seed(settings)
+
+      assert {:ok, ^expected} = process_command("d", settings)
+    end
+
+    test "f runs only failed tests" do
+      settings = %Settings{}
+      expected = Settings.only_failed(settings)
+
+      assert {:ok, ^expected} = process_command("f", settings)
+    end
+
     test "p filters test files to those matching provided pattern" do
       settings = %Settings{}
       expected = Settings.only_patterns(settings, ["pattern"])
@@ -42,20 +70,6 @@ defmodule MixTestInteractive.CommandProcessorTest do
       expected = Settings.only_stale(settings)
 
       assert {:ok, ^expected} = process_command("s", settings)
-    end
-
-    test "f runs only failed tests" do
-      settings = %Settings{}
-      expected = Settings.only_failed(settings)
-
-      assert {:ok, ^expected} = process_command("f", settings)
-    end
-
-    test "a runs all tests" do
-      {:ok, settings} = process_command("s", %Settings{})
-      expected = Settings.all_tests(settings)
-
-      assert {:ok, ^expected} = process_command("a", settings)
     end
 
     test "w toggles watch mode" do

--- a/test/mix_test_interactive/end_to_end_test.exs
+++ b/test/mix_test_interactive/end_to_end_test.exs
@@ -61,6 +61,18 @@ defmodule MixTestInteractive.EndToEndTest do
 
     assert :ok = InteractiveMode.note_file_changed(pid)
     assert_ran_tests(["--stale"])
+
+    assert :ok = InteractiveMode.process_command(pid, "a")
+    assert_ran_tests()
+
+    assert :ok = InteractiveMode.process_command(pid, "d 4242")
+    assert_ran_tests(["--seed", "4242"])
+
+    assert :ok = InteractiveMode.note_file_changed(pid)
+    assert_ran_tests(["--seed", "4242"])
+
+    assert :ok = InteractiveMode.process_command(pid, "d")
+    assert_ran_tests()
   end
 
   defp assert_ran_tests(args \\ []) do

--- a/test/mix_test_interactive/settings_test.exs
+++ b/test/mix_test_interactive/settings_test.exs
@@ -41,6 +41,14 @@ defmodule MixTestInteractive.SettingsTest do
       assert args == ["--trace", "--stale"]
     end
 
+    test "runs with seed" do
+      seed = "5678"
+      settings = Settings.with_seed(%Settings{initial_cli_args: ["--trace"]}, seed)
+
+      {:ok, args} = Settings.cli_args(settings)
+      assert args == ["--trace", "--seed", seed]
+    end
+
     test "pattern filter clears failed flag" do
       settings =
         %Settings{}
@@ -145,10 +153,28 @@ defmodule MixTestInteractive.SettingsTest do
       assert Settings.summary(settings) == "Ran all tests"
     end
 
+    test "ran all tests with seed" do
+      seed = "4242"
+      settings = Settings.with_seed(%Settings{}, seed)
+
+      assert Settings.summary(settings) == "Ran all tests with seed: #{seed}"
+    end
+
     test "ran failed tests" do
       settings = Settings.only_failed(%Settings{})
 
       assert Settings.summary(settings) == "Ran only failed tests"
+    end
+
+    test "ran failed tests with seed" do
+      seed = "4242"
+
+      settings =
+        %Settings{}
+        |> Settings.only_failed()
+        |> Settings.with_seed(seed)
+
+      assert Settings.summary(settings) == "Ran only failed tests with seed: #{seed}"
     end
 
     test "ran stale tests" do
@@ -157,10 +183,26 @@ defmodule MixTestInteractive.SettingsTest do
       assert Settings.summary(settings) == "Ran only stale tests"
     end
 
-    test "ran specific patterns" do
-      settings = Settings.only_patterns(%Settings{}, ["p1", "p2"])
+    test "ran stale tests with seed" do
+      seed = "4242"
 
-      assert Settings.summary(settings) == "Ran all test files matching p1, p2"
+      settings =
+        %Settings{}
+        |> Settings.only_stale()
+        |> Settings.with_seed(seed)
+
+      assert Settings.summary(settings) == "Ran only stale tests with seed: #{seed}"
+    end
+
+    test "ran specific patterns with seed" do
+      seed = "4242"
+
+      settings =
+        %Settings{}
+        |> Settings.only_patterns(["p1", "p2"])
+        |> Settings.with_seed(seed)
+
+      assert Settings.summary(settings) == "Ran all test files matching p1, p2 with seed: #{seed}"
     end
   end
 end


### PR DESCRIPTION
I chose to stick with the pattern of single-character commands, looking ahead to a desired future world where we can respond to keystrokes immediately without having to hit `Enter` first.

Since `s` is already taken by the `stale` command, I choose `d` for `see(d)`, since it's the dominant sound in the word.

Rather that having a separate command for clearing the seed, I chose to use `d` with no argument to clear. There are going to be more commands coming that will want to set/clear a value, so this seemed like the best way to get a clear command without eating up more of the single-character command namespace.