### PR TITLE
🐛 Handle command-line with only patterns

### DIFF
--- a/lib/mix_test_interactive/command_line_parser.ex
+++ b/lib/mix_test_interactive/command_line_parser.ex
@@ -231,10 +231,10 @@ defmodule MixTestInteractive.CommandLineParser do
   end
 
   defp try_parse_as_mti_args(args) do
-    {mti_opts, _args, invalid} = OptionParser.parse(args, strict: @options)
+    {mti_opts, patterns, invalid} = OptionParser.parse(args, strict: @options)
 
     cond do
-      invalid == [] -> {:ok, mti_opts}
+      invalid == [] and patterns == [] -> {:ok, mti_opts}
       mti_opts[:help] || mti_opts[:version] -> {:ok, mti_opts}
       mti_opts == [] -> {:error, :maybe_mix_test_args}
       true -> force_parse_as_mti_args(args)

--- a/test/mix_test_interactive/command_line_parser_test.exs
+++ b/test/mix_test_interactive/command_line_parser_test.exs
@@ -288,6 +288,12 @@ defmodule MixTestInteractive.CommandLineParserTest do
       assert settings.initial_cli_args == ["--color"]
     end
 
+    test "extracts patterns even when no other flags are present" do
+      {:ok, %{settings: settings}} = CommandLineParser.parse(["pattern1", "pattern2"])
+      assert settings.patterns == ["pattern1", "pattern2"]
+      assert settings.initial_cli_args == []
+    end
+
     test "failed takes precedence over stale" do
       {:ok, %{settings: settings}} = CommandLineParser.parse(["--failed", "--stale"])
       refute settings.stale?


### PR DESCRIPTION
The new command-line parsing in v4.0 wasn't properly handling a command-line that had only patterns/filenames as arguments. We were treating that as empty mti options and ignoring the patterns rather than passing the command line on to be parsed as mix test options.

Fixes #122