### PR TITLE
⬆️ Upgrade to Elixir 1.18.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: '1.13'
-            otp: '24'
           - elixir: '1.14'
             otp: '25'
           - elixir: '1.15'
@@ -28,6 +26,8 @@ jobs:
           - elixir: '1.16'
             otp: '26'
           - elixir: '1.17'
+            otp: '27'
+          - elixir: '1.18'
             otp: '27'
     steps:
       - name: Set up Elixir
@@ -80,7 +80,7 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Check formatting
-        if: ${{matrix.elixir == '1.17'}}
+        if: ${{matrix.elixir == '1.18'}}
         run: mix format --check-formatted
 
       - name: Run tests

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.0.1
-elixir 1.17.2-otp-27
+erlang 27.2
+elixir 1.18.1-otp-27


### PR DESCRIPTION
Update CI to run on Elixir 1.14 - 1.18 (adding 1.18 and dropping 1.13).

There have been no changes that warrant dropping support for 1.13, so not updating the minimum Elixir version for now.