### PR TITLE
🚸 Improve ansi-enablement on non-Windows systems

### DIFF
--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -34,7 +34,7 @@ defmodule MixTestInteractive.PortRunner do
           {command, command_args ++ [config.task | task_args]}
 
         _ ->
-          {zombie_killer(), [command] ++ command_args ++ enable_ansi(config.task, task_args)}
+          {zombie_killer(), [command] ++ command_args ++ enable_ansi(config.task) ++ task_args}
       end
 
     runner.(runner_program, runner_program_args,
@@ -45,19 +45,10 @@ defmodule MixTestInteractive.PortRunner do
     :ok
   end
 
-  @no_start_flag "--no-start"
+  defp enable_ansi(task) do
+    enable_command = "Application.put_env(:elixir, :ansi_enabled, true)"
 
-  defp enable_ansi(task, args) do
-    enable_command = "Application.put_env(:elixir, :ansi_enabled, true);"
-
-    {run, task_args} =
-      if @no_start_flag in args do
-        {["run", @no_start_flag, "-e"], List.delete(args, @no_start_flag)}
-      else
-        {["run", "-e"], args}
-      end
-
-    ["do"] ++ run ++ [enable_command, ",", task] ++ task_args
+    ["do", "eval", enable_command, ",", task]
   end
 
   defp zombie_killer do

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -65,23 +65,23 @@ defmodule MixTestInteractive.PortRunnerTest do
     end
 
     test "runs mix test via zombie killer with ansi enabled in test environment by default" do
-      {command, ["mix", "do", "run", "-e", ansi, ",", "test"], options} = run_unix()
+      {command, ["mix", "do", "eval", ansi, ",", "test"], options} = run_unix()
 
       assert command =~ ~r{/zombie_killer$}
       assert ansi =~ ~r/:ansi_enabled/
       assert Keyword.get(options, :env) == [{"MIX_ENV", "test"}]
     end
 
-    test "includes no-start flag in ansi command" do
+    test "passes no-start flag to test task" do
       assert {_command, args, _options} = run_unix(args: ["--no-start"])
 
-      assert ["mix", "do", "run", "--no-start", "-e", _ansi, ",", "test"] = args
+      assert ["mix", "do", "eval", _ansi, ",", "test", "--no-start"] = args
     end
 
     test "appends extra command-line arguments from settings" do
       {_command, args, _options} = run_unix(args: ["--cover"])
 
-      assert ["mix", "do", "run", "-e", _ansi, ",", "test", "--cover"] = args
+      assert ["mix", "do", "eval", _ansi, ",", "test", "--cover"] = args
     end
 
     test "uses custom task" do
@@ -89,7 +89,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert ["mix", "do", "run", "-e", _ansi, ",", "custom_task"] = args
+      assert ["mix", "do", "eval", _ansi, ",", "custom_task"] = args
     end
 
     test "uses custom command with no args" do
@@ -97,7 +97,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert ["custom_command", "do", "run", "-e", _ansi, ",", "test"] = args
+      assert ["custom_command", "do", "eval", _ansi, ",", "test"] = args
     end
 
     test "uses custom command with args" do
@@ -105,7 +105,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
       {_command, args, _options} = run_unix(config: config)
 
-      assert ["custom_command", "--custom_arg", "do", "run", "-e", _ansi, ",", "test"] = args
+      assert ["custom_command", "--custom_arg", "do", "eval", _ansi, ",", "test"] = args
     end
 
     test "prepends command args to test args" do
@@ -113,7 +113,7 @@ defmodule MixTestInteractive.PortRunnerTest do
 
       {_command, args, _options} = run_unix(args: ["--cover"], config: config)
 
-      assert ["custom_command", "--custom_arg", "do", "run", "-e", _ansi, ",", "test", "--cover"] = args
+      assert ["custom_command", "--custom_arg", "do", "eval", _ansi, ",", "test", "--cover"] = args
     end
   end
 end


### PR DESCRIPTION
mix_test_interactive automatically enables ANSI output when running on non-Windows systems.

However, the way we were doing it caused the client application to be started when enabling ANSI output and before running the test task.

Rather than using `run -e` to enable ANSI, we now use `eval` instead, which doesn't start the client application.

As part of this work, we also fix a bug where we weren't handling the `--no-start` flag correctly. Previously, we were grabbing that flag (if present) and passing it to the `run` task, but not to the subsequent test task. As a result, the application would still be started in the test task, which is not what the caller would expect.