### PR TITLE
✨ Make ANSI output configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ arguments, you must separate them with `--`.
 If an option is provided on the command line, it will override the same option
 specified in the configuration.
 
+- `--(no-)ansi-enabled`: Enable ANSI (colored) output when running tests
+  (default `false` on Windows; `true` on other platforms).
 - `--(no-)clear`: Clear the console before each run (default `false`).
 - `--command <command> [--arg <arg>]`: Custom command and arguments for running
   tests (default: "mix" with no arguments). NOTE: Use `--arg` multiple times to
@@ -185,6 +187,23 @@ if Mix.env == :dev do
     clear: true
 end
 ```
+
+### `ansi_enabled`: Enable ANSI (colored) output when running tests
+
+When `ansi_enabled` is set to true, `mix test.interactive` will enable ANSI
+output when running tests, allowing for `mix test`'s normal colored output.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    ansi_enabled: false
+end
+```
+
+The default is `false` on Windows and `true` on other platforms.
 
 ### `command`: Use a custom command
 

--- a/lib/mix/tasks/test/interactive.ex
+++ b/lib/mix/tasks/test/interactive.ex
@@ -32,6 +32,8 @@ defmodule Mix.Tasks.Test.Interactive do
   If an option is provided on the command line, it will override the same option
   specified in the configuration.
 
+  - `--(no-)ansi-enabled`: Enable ANSI (colored) output when running tests
+  (default `false` on Windows; `true` on other platforms).
   - `--(no-)clear`: Clear the console before each run (default `false`).
   - `--command <command> [--arg <arg>]`: Custom command and arguments for
     running tests (default: "mix" with no arguments). NOTE: Use `--arg` multiple
@@ -114,6 +116,8 @@ defmodule Mix.Tasks.Test.Interactive do
   If your project has a `config/config.exs` file, you can customize the
   operation of `mix test.interactive` with the following settings:
 
+  - `ansi_enabled: true`: Enable ANSI (colored) output when running tests
+    (default `false` on Windows; `true` on other platforms).
   - `clear: true`: Clear the console before each run (default: `false`).
   - `command: <program>` or `command: {<program>, [<arg>, ...]}`: Use the
     provided command and arguments to run the test task (default: `mix`).

--- a/lib/mix_test_interactive/command_line_parser.ex
+++ b/lib/mix_test_interactive/command_line_parser.ex
@@ -23,6 +23,7 @@ defmodule MixTestInteractive.CommandLineParser do
   end
 
   @options [
+    ansi_enabled: :boolean,
     arg: :keep,
     clear: :boolean,
     command: :string,
@@ -45,6 +46,9 @@ defmodule MixTestInteractive.CommandLineParser do
 
   where:
     <mti_args>:
+      --(no-)ansi-enabled             Enable ANSI (colored) output when running tests
+                                      (default `false` on Windows; `true` on other
+                                      platforms).
       --(no-)clear                    Clear the console before each run
                                       (default: `false`)
       --command <command>/--arg <arg> Custom command and arguments for running
@@ -141,6 +145,7 @@ defmodule MixTestInteractive.CommandLineParser do
     config =
       mti_opts
       |> Enum.reduce(Config.load_from_environment(), fn
+        {:ansi_enabled, enabled?}, config -> %{config | ansi_enabled?: enabled?}
         {:clear, clear?}, config -> %{config | clear?: clear?}
         {:exclude, excludes}, config -> %{config | exclude: excludes}
         {:extra_extensions, extra_extensions}, config -> %{config | extra_extensions: extra_extensions}

--- a/test/mix_test_interactive/command_line_parser_test.exs
+++ b/test/mix_test_interactive/command_line_parser_test.exs
@@ -62,7 +62,19 @@ defmodule MixTestInteractive.CommandLineParserTest do
   describe "mix test.interactive options" do
     test "retains original defaults when no options" do
       {:ok, %{config: config}} = CommandLineParser.parse([])
-      assert config == %Config{}
+      assert config == Config.new()
+    end
+
+    test "sets ansi_enabled? flag with --ansi-enabled" do
+      Process.put(:os_type, {:win32, :nt})
+      {:ok, %{config: config}} = CommandLineParser.parse(["--ansi-enabled"])
+      assert config.ansi_enabled?
+    end
+
+    test "clears ansi_enabled? flag with --no-ansi-enabled" do
+      Process.put(:os_type, {:unix, :darwin})
+      {:ok, %{config: config}} = CommandLineParser.parse(["--no-ansi-enabled"])
+      refute config.ansi_enabled?
     end
 
     test "sets clear? flag with --clear" do

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -4,6 +4,25 @@ defmodule MixTestInteractive.ConfigTest do
   alias MixTestInteractive.Config
 
   describe "loading from the environment" do
+    test "takes :ansi_enabled? from the env" do
+      Process.put(:os_type, {:unix, :darwin})
+      Process.put(:ansi_enabled, false)
+      config = Config.load_from_environment()
+      refute config.ansi_enabled?
+    end
+
+    test "defaults :ansi_enabled? to false on Windows" do
+      Process.put(:os_type, {:win32, :nt})
+      config = Config.load_from_environment()
+      refute config.ansi_enabled?
+    end
+
+    test "defaults :ansi_enabled? to true on other platforms" do
+      Process.put(:os_type, {:unix, :darwin})
+      config = Config.load_from_environment()
+      assert config.ansi_enabled?
+    end
+
     test "takes :clear? from the env" do
       Process.put(:clear, true)
       config = Config.load_from_environment()


### PR DESCRIPTION
Previously, we always enabled ANSI output on Unix-like systems and we didn't on Windows.

However, since Windows 10, ANSI has been available on Windows as well (if the [appropriate registry key is set](https://hexdocs.pm/elixir/IO.ANSI.html)), so we provide a way for users to opt-in if desired.

It is also now possible to run with ANSI output off on Unix-like systems if necessary for any reason.

ANSI output can be enabled/disabled via the `ansi_enabled` configuration setting or the `(no-)ansi-enabled` command line option.

We also modify `PortRunner` to take the `os_type` from ProcessTree instead of passing an argument, which matches the changes we made to Config to support the new setting.

We significantly refactor the PortRunner tests to eliminate many near-duplicate tests.