### PR TITLE
Add verbose option/config for printing the test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ specified in the configuration.
 - `--task <task name>`: Run a different mix task (default: `"test"`).
 - `--(no-)timestamp`: Display the current time before running the tests
   (default: `false`).
+- `--(no-)verbose`: Display the command to be run before running the tests
+  (default: `false`).
 - `--(no-)watch`: Don't run tests when a file changes (default: `true`).
 
 All of the `<mix test arguments>` are passed through to `mix test` on every test
@@ -340,6 +342,21 @@ import Config
 if Mix.env == :dev do
   config :mix_test_interactive,
     timestamp: true
+end
+```
+
+### `verbose`: Display the command to be run before running the tests
+
+When `verbose` is set to true, `mix test.interactive` will display the command
+line it is about to execute just before running the tests.
+
+```elixir
+# config/config.exs
+import Config
+
+if Mix.env == :dev do
+  config :mix_test_interactive,
+    verbose: true
 end
 ```
 

--- a/lib/mix/tasks/test/interactive.ex
+++ b/lib/mix/tasks/test/interactive.ex
@@ -48,6 +48,8 @@ defmodule Mix.Tasks.Test.Interactive do
   - `--task <task name>`: Run a different mix task (default: `"test"`).
   - `--(no-)timestamp`: Display the current time before running the tests
     (default: `false`).
+  - `--(no-)verbose`: Display the command to be run before running the tests
+    (default: `false`).
   - `--(no-)watch`: Don't run tests when a file changes (default: `true`).
 
   All of the `<mix test arguments>` are passed through to `mix test` on every
@@ -129,8 +131,10 @@ defmodule Mix.Tasks.Test.Interactive do
     `MixTestInteractive.PortRunner`).
   - `task: <task name>`: The mix task to use when running tests (default:
     `"test"`).
-  - `timestamp: true`: Print current time (UTC) before running tests (default:
-    false).
+  - `timestamp: true`: Display the current time (UTC) before running the tests
+    (default: false).
+  - `verbose: true`: Display the command to be run before running the tests
+    (default: `false`)
   """
 
   use Mix.Task

--- a/lib/mix_test_interactive/command_line_formatter.ex
+++ b/lib/mix_test_interactive/command_line_formatter.ex
@@ -1,0 +1,38 @@
+defmodule MixTestInteractive.CommandLineFormatter do
+  @moduledoc false
+
+  @special_chars ~r/[\s&|;<>*?()\[\]{}$`'"]/
+  @whitespace ~r/\s/
+
+  def call(command, args) do
+    Enum.map_join([command | args], " ", &format_argument/1)
+  end
+
+  defp format_argument(arg) do
+    if arg =~ @special_chars do
+      quote_argument(arg)
+    else
+      arg
+    end
+  end
+
+  defp quote_argument(arg) do
+    cond do
+      # Prefer double quotes for arguments with only spaces or special characters
+      String.match?(arg, @whitespace) and not String.contains?(arg, ~s(")) ->
+        ~s("#{arg}")
+
+      # Use single quotes if the argument contains double quotes but no single quotes
+      String.contains?(arg, ~s(")) and not String.contains?(arg, "'") ->
+        ~s('#{arg}')
+
+      # Escape single quotes using the '"'"' trick if both quotes are present
+      String.contains?(arg, "'") ->
+        ~s('#{String.replace(arg, "'", "'\\''")}')
+
+      # Default to double quotes for other special characters
+      true ->
+        ~s("#{arg}")
+    end
+  end
+end

--- a/lib/mix_test_interactive/command_line_parser.ex
+++ b/lib/mix_test_interactive/command_line_parser.ex
@@ -33,6 +33,7 @@ defmodule MixTestInteractive.CommandLineParser do
     runner: :string,
     task: :string,
     timestamp: :boolean,
+    verbose: :boolean,
     version: :boolean,
     watch: :boolean
   ]
@@ -70,6 +71,8 @@ defmodule MixTestInteractive.CommandLineParser do
                                       (default: `"test"`)
       --(no-)timestamp                Display the current time before running
                                       the tests (default: `false`)
+      --(no-)verbose                  Display the command to be run before
+                                      running the tests (default: `false`)
       --(no-)watch                    Run tests when a watched file changes
                                       (default: `true`)
 
@@ -152,6 +155,7 @@ defmodule MixTestInteractive.CommandLineParser do
         {:runner, runner}, config -> %{config | runner: runner}
         {:timestamp, show_timestamp?}, config -> %{config | show_timestamp?: show_timestamp?}
         {:task, task}, config -> %{config | task: task}
+        {:verbose, verbose}, config -> %{config | verbose?: verbose}
         _pair, config -> config
       end)
       |> handle_custom_command(mti_opts)

--- a/lib/mix_test_interactive/config.ex
+++ b/lib/mix_test_interactive/config.ex
@@ -7,14 +7,15 @@ defmodule MixTestInteractive.Config do
   @application :mix_test_interactive
 
   typedstruct do
-    field :ansi_enabled?, boolean
-    field :clear?, boolean, default: false
+    field :ansi_enabled?, boolean()
+    field :clear?, boolean(), default: false
     field :command, {String.t(), [String.t()]}, default: {"mix", []}
     field :exclude, [Regex.t()], default: [~r/\.#/, ~r{priv/repo/migrations}]
     field :extra_extensions, [String.t()], default: []
     field :runner, module(), default: MixTestInteractive.PortRunner
     field :show_timestamp?, boolean(), default: false
     field :task, String.t(), default: "test"
+    field :verbose?, boolean(), default: false
   end
 
   @doc """
@@ -31,6 +32,7 @@ defmodule MixTestInteractive.Config do
     |> load(:runner)
     |> load(:timestamp, rename: :show_timestamp?)
     |> load(:task)
+    |> load(:verbose, rename: :verbose?)
   end
 
   @doc false

--- a/lib/mix_test_interactive/port_runner.ex
+++ b/lib/mix_test_interactive/port_runner.ex
@@ -11,6 +11,7 @@ defmodule MixTestInteractive.PortRunner do
   """
   @behaviour MixTestInteractive.TestRunner
 
+  alias MixTestInteractive.CommandLineFormatter
   alias MixTestInteractive.Config
   alias MixTestInteractive.TestRunner
 
@@ -37,6 +38,8 @@ defmodule MixTestInteractive.PortRunner do
           {zombie_killer(), [command] ++ command_args ++ task ++ task_args}
       end
 
+    maybe_print_command(config, runner_program, runner_program_args)
+
     runner.(runner_program, runner_program_args,
       env: [{"MIX_ENV", "test"}],
       into: IO.stream(:stdio, :line)
@@ -49,6 +52,14 @@ defmodule MixTestInteractive.PortRunner do
     enable_command = "Application.put_env(:elixir, :ansi_enabled, true)"
 
     ["do", "eval", enable_command, ",", task]
+  end
+
+  defp maybe_print_command(%Config{verbose?: false} = _config, _runner_program, _runner_program_args), do: :ok
+
+  defp maybe_print_command(%Config{} = _config, runner_program, runner_program_args) do
+    runner_program
+    |> CommandLineFormatter.call(runner_program_args)
+    |> IO.puts()
   end
 
   defp zombie_killer do

--- a/test/mix_test_interactive/command_line_formatter_test.exs
+++ b/test/mix_test_interactive/command_line_formatter_test.exs
@@ -1,0 +1,38 @@
+defmodule MixTestInteractive.CommandLineFormatterTest do
+  use ExUnit.Case, async: true
+
+  alias MixTestInteractive.CommandLineFormatter
+
+  describe "formatting a command line with proper quoting" do
+    test "formats simple commands without quoting" do
+      assert CommandLineFormatter.call("mix", ["test", "--stale", "file.exs"]) ==
+               ~s(mix test --stale file.exs)
+    end
+
+    test "double-quotes arguments with spaces" do
+      assert CommandLineFormatter.call("mix", ["test", "file with spaces.txt"]) ==
+               ~s(mix test "file with spaces.txt")
+    end
+
+    test "double-quotes arguments with special characters" do
+      args = ["do", "eval", "Application.put_env(:elixir,:ansi_enabled,true)", ",", "test"]
+      expected = ~s[mix do eval "Application.put_env(:elixir,:ansi_enabled,true)" , test]
+
+      assert CommandLineFormatter.call("mix", args) == expected
+    end
+
+    test "single-quotes arguments containing only double quotes" do
+      args = ["do", "eval", ~s[IO.puts("running tests!")], ",", "test"]
+      expected = ~s[mix do eval 'IO.puts("running tests!")' , test]
+
+      assert CommandLineFormatter.call("mix", args) == expected
+    end
+
+    test "double-quotes arguments with mixed single and double quotes" do
+      args = ["do", "eval", ~s[IO.puts("I'm testing")], ",", "test"]
+      expected = ~s[mix do eval 'IO.puts(\"I'\\''m testing\")' , test]
+
+      assert CommandLineFormatter.call("mix", args) == expected
+    end
+  end
+end

--- a/test/mix_test_interactive/command_line_parser_test.exs
+++ b/test/mix_test_interactive/command_line_parser_test.exs
@@ -156,6 +156,16 @@ defmodule MixTestInteractive.CommandLineParserTest do
       refute config.show_timestamp?
     end
 
+    test "sets verbose? flag with --verbose" do
+      {:ok, %{config: config}} = CommandLineParser.parse(["--verbose"])
+      assert config.verbose?
+    end
+
+    test "clears verbose? flag with --no-verbose" do
+      {:ok, %{config: config}} = CommandLineParser.parse(["--no-verbose"])
+      refute config.verbose?
+    end
+
     test "configures custom mix task with --task" do
       {:ok, %{config: config}} = CommandLineParser.parse(["--task", "custom_task"])
       assert config.task == "custom_task"

--- a/test/mix_test_interactive/config_test.exs
+++ b/test/mix_test_interactive/config_test.exs
@@ -97,5 +97,16 @@ defmodule MixTestInteractive.ConfigTest do
       config = Config.load_from_environment()
       assert config.task == "test"
     end
+
+    test "takes :verbose from the env" do
+      Process.put(:verbose, true)
+      config = Config.load_from_environment()
+      assert config.verbose?
+    end
+
+    test "defaults verbose to false" do
+      config = Config.load_from_environment()
+      refute config.verbose?
+    end
   end
 end

--- a/test/mix_test_interactive/port_runner_test.exs
+++ b/test/mix_test_interactive/port_runner_test.exs
@@ -1,6 +1,8 @@
 defmodule MixTestInteractive.PortRunnerTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureIO
+
   alias MixTestInteractive.Config
   alias MixTestInteractive.PortRunner
 
@@ -105,6 +107,22 @@ defmodule MixTestInteractive.PortRunnerTest do
 
         assert {"custom_command", ["--custom_arg", "test", "--cover"], _options} =
                  run(args: ["--cover"], config: config)
+      end
+
+      test "does not display command by default" do
+        {result, output} = with_io(fn -> run() end)
+
+        assert {"mix", _args, _env} = result
+        assert output == ""
+      end
+
+      test "displays command in verbose mode" do
+        config = config(%{verbose?: true})
+
+        {result, output} = with_io(fn -> run(config: config) end)
+
+        assert {"mix", _args, _env} = result
+        assert output =~ "mix test"
       end
     end
   end


### PR DESCRIPTION
The new option (off by default) allows you to see the command that will be run just before running the tests. Might be useful to understand what's happening under the hood when diagnosing strange behavior.