### PR TITLE
Prepare for Elixir 1.19

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
             otp: '27'
           - elixir: '1.18'
             otp: '27'
+          - elixir: main
+            otp: '27'
     steps:
       - name: Set up Elixir
         id: setup


### PR DESCRIPTION
We believe that there is a breaking change coming in 1.19 regarding the separator character for `mix do` (changes from `,` to `+`). We want to verify that by building against elixir `main`. If the breaking change is present, the build will fail and we can update our code (though we'll have to drop support for Elixir 1.13 as a result).