### PR TITLE
✨ Allow relative pathname patterns

### DIFF
--- a/lib/mix_test_interactive/command_line_parser.ex
+++ b/lib/mix_test_interactive/command_line_parser.ex
@@ -1,8 +1,6 @@
 defmodule MixTestInteractive.CommandLineParser do
   @moduledoc false
 
-  use TypedStruct
-
   alias MixTestInteractive.Config
   alias MixTestInteractive.Settings
   alias OptionParser.ParseError

--- a/lib/mix_test_interactive/pattern_filter.ex
+++ b/lib/mix_test_interactive/pattern_filter.ex
@@ -18,11 +18,23 @@ defmodule MixTestInteractive.PatternFilter do
   end
 
   def matches(files, patterns) do
-    {with_line_number, simple} = Enum.split_with(patterns, &is_line_number_pattern?/1)
+    {with_line_number, simple} =
+      patterns
+      |> convert_relative_filenames_to_patterns()
+      |> Enum.split_with(&is_line_number_pattern?/1)
 
     files
     |> Enum.filter(&String.contains?(&1, simple))
-    |> Kernel.++(with_line_number)
+    |> Enum.concat(with_line_number)
+  end
+
+  defp convert_relative_filenames_to_patterns(patterns) do
+    for pattern <- patterns do
+      case Path.safe_relative(pattern) do
+        {:ok, filename} -> filename
+        :error -> pattern
+      end
+    end
   end
 
   if Version.compare(System.version(), "1.20.0-dev") == :lt do

--- a/test/mix_test_interactive/pattern_filter_test.exs
+++ b/test/mix_test_interactive/pattern_filter_test.exs
@@ -34,8 +34,21 @@ defmodule MixTestInteractive.PatternFilterTest do
     assert matches == patterns
   end
 
-  test "returns a mix of matching files and files with line numbers" do
-    patterns = ["some_test.exs:42", "bc", "other_test.exs:58"]
+  test "returns files with relative pathnames" do
+    pattern = "./#{@abc}"
+    matches = PatternFilter.matches(@files, pattern)
+
+    assert matches == [@abc]
+  end
+
+  test "uses non-relative pathnames as normal patterns" do
+    pattern = Path.expand("./#{@bcd}")
+    matches = PatternFilter.matches(@files, pattern)
+    assert matches == []
+  end
+
+  test "returns a mix of matching files, relative pathnames, and files with line numbers" do
+    patterns = ["some_test.exs:42", "ab", "other_test.exs:58", "./#{@bcd}"]
     matches = PatternFilter.matches(@files, patterns)
 
     assert matches == [@abc, @bcd, "some_test.exs:42", "other_test.exs:58"]


### PR DESCRIPTION
`mix test` allows filenames of the form `./test/hello/hello_test.exs`, but `mix test.interactive` did not.

While we treat command-line arguments as patterns and not filenames, it's confusing that something that works with `mix test` doesn't work with `mix test.interactive`.

We now convert relative pathnames into patterns that will match the list of test files we find in the project.

While `mix test` also supports absolute paths and paths outside of the current project, we choose not to do that here.

Closes #142