### PR TITLE
Fix docs source_ref

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule MixTestInteractive.MixProject do
         Commands: [~r/^MixTestInteractive\.Command\..*/]
       ],
       main: "readme",
-      source_ref: "#{@version}"
+      source_ref: "v#{@version}"
     ]
   end
 


### PR DESCRIPTION
The tags on the target repository start with a v:
https://github.com/randycoulman/mix_test_interactive/releases